### PR TITLE
[react] Support stateless-functional-components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import isStatelessComponent from './isStatelessComponent';
+
 export default function ({ Plugin, types: t }) {
   return {
     visitor: {
@@ -52,12 +54,17 @@ export default function ({ Plugin, types: t }) {
 
             const className = node.left.object.name;
             const binding = scope.getBinding(className);
-            if (!binding || !binding.path.isClassDeclaration()) {
+
+            if (!binding) {
               return;
             }
 
-            const superClass = binding.path.get('superClass');
-            if (superClass.matchesPattern('React.Component') || superClass.matchesPattern('Component')) {
+            if (binding.path.isClassDeclaration()) {
+              const superClass = binding.path.get('superClass');
+              if (superClass.matchesPattern('React.Component') || superClass.matchesPattern('Component')) {
+                path.remove();
+              }
+            } else if (isStatelessComponent(binding.path)) {
               path.remove();
             }
           },
@@ -65,4 +72,4 @@ export default function ({ Plugin, types: t }) {
       },
     },
   };
-};
+}

--- a/src/isStatelessComponent.js
+++ b/src/isStatelessComponent.js
@@ -1,0 +1,60 @@
+function isReturningJSXElement(path) {
+  /**
+   * Early exit for ArrowFunctionExpressions, there is no ReturnStatement node.
+   */
+  if (path.node.init && path.node.init.body && path.node.init.body.type === 'JSXElement') {
+    return true;
+  }
+
+  let visited = false;
+
+  path.traverse({
+    ReturnStatement(path2) {
+      // We have already found what we are looking for.
+      if (visited) {
+        return;
+      }
+
+      const argument = path2.get('argument');
+
+      if (argument.node.type === 'JSXElement') {
+        visited = true;
+      } else if (argument.node.type === 'CallExpression') {
+        const name = argument.get('callee').node.name;
+        const binding = path.scope.getBinding(name);
+
+        if (!binding) {
+          return;
+        }
+
+        if (isReturningJSXElement(binding.path)) {
+          visited = true;
+        }
+      }
+    },
+  });
+
+  return visited;
+}
+
+const validPossibleStatelessComponentTypes = [
+  'VariableDeclarator',
+  'FunctionDeclaration',
+];
+
+/**
+ * Returns `true` if the path represents a function which returns a JSXElment
+ */
+export default function isStatelessComponent(path) {
+  const node = path.node;
+
+  if (validPossibleStatelessComponentTypes.indexOf(node.type) === -1) {
+    return false;
+  }
+
+  if (isReturningJSXElement(path)) {
+    return true;
+  }
+
+  return false;
+}

--- a/test/fixtures/stateless-functional-components/actual.js
+++ b/test/fixtures/stateless-functional-components/actual.js
@@ -1,0 +1,93 @@
+const Foo1 = () => (
+  <div />
+);
+
+Foo1.propTypes = {
+  foo: React.PropTypes.string
+};
+
+const Foo2 = () => {
+  return <div />;
+};
+
+Foo2.propTypes = {
+  foo: React.PropTypes.string
+};
+
+const Foo3 = function() {
+  switch(true) {
+    case true:
+      if (true) {
+        return <div />;
+      } else {
+        return <span />;
+      }
+      break;
+  }
+};
+
+Foo3.propTypes = {
+  foo: React.PropTypes.string
+};
+
+function Foo4() {
+  return <div />;
+}
+
+Foo4.propTypes = {
+  foo: React.PropTypes.string
+};
+
+function Foo5() {
+  const bar5 = function() {
+    return <div />;
+  }
+
+  return bar5();
+}
+
+Foo5.propTypes = {
+  foo: React.PropTypes.string
+};
+
+function Foo6() {
+  var result = bar6();
+
+  return result;
+
+  function bar6() {
+    return <div />;
+  }
+}
+
+Foo6.propTypes = {
+  foo: React.PropTypes.string
+};
+
+function Foo7() {
+  const shallow = {
+    shallowMember() {
+      return <div />;
+    }
+  };
+  return shallow.shallowMember();
+}
+
+Foo7.propTypes = {
+  foo: React.PropTypes.string
+};
+
+function Foo8() {
+  const obj = {
+    deep: {
+      member() {
+        return <div />;
+      }
+    }
+  };
+  return obj.deep.member();
+}
+
+Foo8.propTypes = {
+  foo: React.PropTypes.string
+};

--- a/test/fixtures/stateless-functional-components/expected.js
+++ b/test/fixtures/stateless-functional-components/expected.js
@@ -1,0 +1,63 @@
+"use strict";
+
+var Foo1 = function Foo1() {
+  return React.createElement("div", null);
+};
+
+var Foo2 = function Foo2() {
+  return React.createElement("div", null);
+};
+
+var Foo3 = function Foo3() {
+  switch (true) {
+    case true:
+      if (true) {
+        return React.createElement("div", null);
+      } else {
+        return React.createElement("span", null);
+      }
+      break;
+  }
+};
+
+function Foo4() {
+  return React.createElement("div", null);
+}
+
+function Foo5() {
+  var bar5 = function bar5() {
+    return React.createElement("div", null);
+  };
+
+  return bar5();
+}
+
+function Foo6() {
+  var result = bar6();
+
+  return result;
+
+  function bar6() {
+    return React.createElement("div", null);
+  }
+}
+
+function Foo7() {
+  var shallow = {
+    shallowMember: function shallowMember() {
+      return React.createElement("div", null);
+    }
+  };
+  return shallow.shallowMember();
+}
+
+function Foo8() {
+  var obj = {
+    deep: {
+      member: function member() {
+        return React.createElement("div", null);
+      }
+    }
+  };
+  return obj.deep.member();
+}


### PR DESCRIPTION
Fix https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/issues/1.
I'm not completly happy with this PR.

I wanted to support pattern like the following.
```js
      function Foo (props) {
        var member = () => <div />;
        var obj = {
          deep: {
            member: member
          }
        };
        return obj.deep.member();
      }
```

And I wanted to check the scope when looking for returned `JSXElement` element.
I couldn't make it work.