### PR TITLE
[Class] Fix issue 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "babel-core": "^6.3.26"
   },
   "devDependencies": {
-    "babel-cli": "^6.3.17",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-cli": "^6.6.4",
+    "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "istanbul": "^0.4.2",

--- a/src/index.js
+++ b/src/index.js
@@ -38,14 +38,16 @@ export default function ({ Plugin, types: t }) {
               let binding = scope.getBinding(className);
               let superClass = binding.path.get('superClass');
 
-              if (superClass.matchesPattern('React.Component') || superClass.node.name === 'Component') {
+              if (superClass.matchesPattern('React.Component') ||
+                superClass.node.name === 'Component') {
                 path.remove();
               } else if (superClass.node.name) { // Check for inheritance
                 className = superClass.node.name;
                 binding = scope.getBinding(className);
                 superClass = binding.path.get('superClass');
 
-                if (superClass.matchesPattern('React.Component') || superClass.node.name === 'Component') {
+                if (superClass.matchesPattern('React.Component') ||
+                  (superClass.node && superClass.node.name === 'Component')) {
                   path.remove();
                 }
               }

--- a/test/fixtures/es-class-inheritance-deopt/actual.js
+++ b/test/fixtures/es-class-inheritance-deopt/actual.js
@@ -1,0 +1,9 @@
+import BaseComponent from 'components/base';
+
+class Foo extends BaseComponent {
+  static propTypes = {
+    foo: PropTypes.string.isRequired
+  };
+  render () {
+  }
+}

--- a/test/fixtures/es-class-inheritance-deopt/expected.js
+++ b/test/fixtures/es-class-inheritance-deopt/expected.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _base = require('components/base');
+
+var _base2 = _interopRequireDefault(_base);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Foo = function (_BaseComponent) {
+  _inherits(Foo, _BaseComponent);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(Foo).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: 'render',
+    value: function render() {}
+  }]);
+
+  return Foo;
+}(_base2.default);
+
+Foo.propTypes = {
+  foo: PropTypes.string.isRequired
+};


### PR DESCRIPTION
This PR is fixing an issue when the extended class can't be find by babel.
It's also taking a side by only accepting `React.Component` and the `Component` class name.
Anything else as `BaseComponent` won't be optimised.

Fix #7.