### PR TITLE
[ES6] Add support for class without name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,16 +34,16 @@ export default function ({ Plugin, types: t }) {
             } = path;
 
             if (node.key.name === 'propTypes') {
-              let className = scope.block.id.name;
-              let binding = scope.getBinding(className);
-              let superClass = binding.path.get('superClass');
+              const id = scope.block.id;
+
+              let superClass = scope.path.get('superClass');
 
               if (superClass.matchesPattern('React.Component') ||
                 superClass.node.name === 'Component') {
                 path.remove();
               } else if (superClass.node.name) { // Check for inheritance
-                className = superClass.node.name;
-                binding = scope.getBinding(className);
+                const className = superClass.node.name;
+                const binding = scope.getBinding(className);
                 superClass = binding.path.get('superClass');
 
                 if (superClass.matchesPattern('React.Component') ||

--- a/test/fixtures/es-class-no-name/actual.js
+++ b/test/fixtures/es-class-no-name/actual.js
@@ -1,0 +1,7 @@
+export default class extends React.Component {
+  static propTypes = {
+    foo: React.PropTypes.string
+  };
+
+  render() {}
+}

--- a/test/fixtures/es-class-no-name/expected.js
+++ b/test/fixtures/es-class-no-name/expected.js
@@ -1,0 +1,32 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var _class = function (_React$Component) {
+  _inherits(_class, _React$Component);
+
+  function _class() {
+    _classCallCheck(this, _class);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(_class).apply(this, arguments));
+  }
+
+  _createClass(_class, [{
+    key: "render",
+    value: function render() {}
+  }]);
+
+  return _class;
+}(React.Component);
+
+exports.default = _class;


### PR DESCRIPTION
Fix https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/issues/9.