### PR TITLE
Add test cases for intermediate variable

### DIFF
--- a/test/fixtures/es-class-assign-property-variable-export/actual.js
+++ b/test/fixtures/es-class-assign-property-variable-export/actual.js
@@ -1,0 +1,9 @@
+export const propTypes = {
+  foo: React.PropTypes.string
+};
+
+class Foo extends React.Component {
+  render() {}
+}
+
+Foo.propTypes = propTypes;

--- a/test/fixtures/es-class-assign-property-variable-export/expected.js
+++ b/test/fixtures/es-class-assign-property-variable-export/expected.js
@@ -1,0 +1,34 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var propTypes = exports.propTypes = {
+  foo: React.PropTypes.string
+};
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(Foo).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: "render",
+    value: function render() {}
+  }]);
+
+  return Foo;
+}(React.Component);

--- a/test/fixtures/es-class-assign-property-variable/actual.js
+++ b/test/fixtures/es-class-assign-property-variable/actual.js
@@ -1,0 +1,9 @@
+const propTypes = {
+  foo: React.PropTypes.string
+};
+
+class Foo extends React.Component {
+  render() {}
+}
+
+Foo.propTypes = propTypes;

--- a/test/fixtures/es-class-assign-property-variable/expected.js
+++ b/test/fixtures/es-class-assign-property-variable/expected.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var propTypes = {
+  foo: React.PropTypes.string
+};
+
+var Foo = function (_React$Component) {
+  _inherits(Foo, _React$Component);
+
+  function Foo() {
+    _classCallCheck(this, Foo);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(Foo).apply(this, arguments));
+  }
+
+  _createClass(Foo, [{
+    key: "render",
+    value: function render() {}
+  }]);
+
+  return Foo;
+}(React.Component);


### PR DESCRIPTION
I was curious about how this plugin treated code that assigns propTypes
to an intermediate variable. I'm not entirely sure if this is the
desired affect, but I figured I would add a couple of test cases that
demonstrate this.

I wanted to test exported and non-exported variables separately in case
there was a difference, but it turned out to not have much difference.

One possible avenue for improvement would be for non-exported, unused,
intermediate variables to be removed--but perhaps that is the domain of
a separate plugin.