### PR TITLE
[ES5] Support transpilated code?

### DIFF
--- a/test/fixtures/es5-transpiled/actual.js
+++ b/test/fixtures/es5-transpiled/actual.js
@@ -1,0 +1,44 @@
+"use strict";
+
+React.createClass({
+  propTypes: {
+    foo: React.PropTypes.string
+  }
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Foo1 = function (_React$Component) {
+  _inherits(Foo1, _React$Component);
+
+  function Foo1() {
+    _classCallCheck(this, Foo1);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(Foo1).apply(this, arguments));
+  }
+
+  _createClass(Foo1, [{
+    key: "render",
+    value: function render() {}
+  }]);
+
+  return Foo1;
+}(React.Component);
+
+Foo1.propTypes = {
+  foo: React.PropTypes.string
+};
+
+var Foo2 = function Foo2() {
+  return React.createElement("div", null);
+};
+
+Foo2.propTypes = {
+  foo: React.PropTypes.string
+};

--- a/test/fixtures/es5-transpiled/expected-remove.js
+++ b/test/fixtures/es5-transpiled/expected-remove.js
@@ -1,0 +1,54 @@
+"use strict";
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+
+React.createClass({});
+
+var _createClass = function () {
+  function defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];descriptor.enumerable = descriptor.enumerable || false;descriptor.configurable = true;if ("value" in descriptor) descriptor.writable = true;Object.defineProperty(target, descriptor.key, descriptor);
+    }
+  }return function (Constructor, protoProps, staticProps) {
+    if (protoProps) defineProperties(Constructor.prototype, protoProps);if (staticProps) defineProperties(Constructor, staticProps);return Constructor;
+  };
+}();
+
+function _classCallCheck(instance, Constructor) {
+  if (!(instance instanceof Constructor)) {
+    throw new TypeError("Cannot call a class as a function");
+  }
+}
+
+function _possibleConstructorReturn(self, call) {
+  if (!self) {
+    throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+  }return call && ((typeof call === "undefined" ? "undefined" : _typeof(call)) === "object" || typeof call === "function") ? call : self;
+}
+
+function _inherits(subClass, superClass) {
+  if (typeof superClass !== "function" && superClass !== null) {
+    throw new TypeError("Super expression must either be null or a function, not " + (typeof superClass === "undefined" ? "undefined" : _typeof(superClass)));
+  }subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } });if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
+}
+
+var Foo1 = function (_React$Component) {
+  _inherits(Foo1, _React$Component);
+
+  function Foo1() {
+    _classCallCheck(this, Foo1);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(Foo1).apply(this, arguments));
+  }
+
+  _createClass(Foo1, [{
+    key: "render",
+    value: function render() {}
+  }]);
+
+  return Foo1;
+}(React.Component);
+
+var Foo2 = function Foo2() {
+  return React.createElement("div", null);
+};

--- a/test/fixtures/es5-transpiled/expected-wrap.js
+++ b/test/fixtures/es5-transpiled/expected-wrap.js
@@ -1,0 +1,62 @@
+"use strict";
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+
+React.createClass({
+  propTypes: {
+    foo: React.PropTypes.string
+  }
+});
+
+var _createClass = function () {
+  function defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];descriptor.enumerable = descriptor.enumerable || false;descriptor.configurable = true;if ("value" in descriptor) descriptor.writable = true;Object.defineProperty(target, descriptor.key, descriptor);
+    }
+  }return function (Constructor, protoProps, staticProps) {
+    if (protoProps) defineProperties(Constructor.prototype, protoProps);if (staticProps) defineProperties(Constructor, staticProps);return Constructor;
+  };
+}();
+
+function _classCallCheck(instance, Constructor) {
+  if (!(instance instanceof Constructor)) {
+    throw new TypeError("Cannot call a class as a function");
+  }
+}
+
+function _possibleConstructorReturn(self, call) {
+  if (!self) {
+    throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+  }return call && ((typeof call === "undefined" ? "undefined" : _typeof(call)) === "object" || typeof call === "function") ? call : self;
+}
+
+function _inherits(subClass, superClass) {
+  if (typeof superClass !== "function" && superClass !== null) {
+    throw new TypeError("Super expression must either be null or a function, not " + (typeof superClass === "undefined" ? "undefined" : _typeof(superClass)));
+  }subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } });if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
+}
+
+var Foo1 = function (_React$Component) {
+  _inherits(Foo1, _React$Component);
+
+  function Foo1() {
+    _classCallCheck(this, Foo1);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(Foo1).apply(this, arguments));
+  }
+
+  _createClass(Foo1, [{
+    key: "render",
+    value: function render() {}
+  }]);
+
+  return Foo1;
+}(React.Component);
+
+var Foo2 = function Foo2() {
+  return React.createElement("div", null);
+};
+
+process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
+  foo: React.PropTypes.string
+} : void 0;


### PR DESCRIPTION
This is a new test to see how the plugin behaves with already transpiled code by babel.
That not working with the ES6 class syntax.
I'm not sure we should support it.

Illustrate for #38.