### PR TITLE
Fix .babelrc example configuration with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ with options:
 {
   "env": {
     "production": {
-      "plugins": ["transform-react-remove-prop-types", {"mode": "wrap"}]
+      "plugins": [["transform-react-remove-prop-types", {"mode": "wrap"}]]
     }
   }
 }


### PR DESCRIPTION
Plugins specifying options must be wrapped in an array with the plugin name, as shown in the node API example.