### PR TITLE
fix(stateless): go deeper in the return statement to look for React element

### DIFF
--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -17,13 +17,14 @@ const modes = ['remove-es5', 'wrap-es5', 'remove-es6', 'wrap-es6'];
 describe('fixtures', () => {
   const fixturesDir = path.join(__dirname, 'fixtures');
 
-  fs.readdirSync(fixturesDir).map((caseName) => {
+  fs.readdirSync(fixturesDir).forEach((caseName) => {
     describe(`should work with ${caseName.split('-').join(' ')}`, () => {
       const fixtureDir = path.join(fixturesDir, caseName);
 
-      modes.map((mode) => {
+      modes.forEach((mode) => {
         let expected;
 
+        // Only run the check if the expect file is provided
         try {
           expected = fs.readFileSync(path.join(fixtureDir, `expected-${mode}.js`));
           expected = expected.toString();

--- a/test/fixtures/stateless-functional-components/actual.js
+++ b/test/fixtures/stateless-functional-components/actual.js
@@ -107,3 +107,11 @@ const Foo10 = () => {
 Foo10.propTypes = {
   foo: React.PropTypes.string
 };
+
+const Foo11 = () => (
+  true && <div />
+);
+
+Foo11.propTypes = {
+  foo: React.PropTypes.string
+};

--- a/test/fixtures/stateless-functional-components/expected-remove-es5.js
+++ b/test/fixtures/stateless-functional-components/expected-remove-es5.js
@@ -69,3 +69,7 @@ var Foo9 = function Foo9() {
 var Foo10 = function Foo10() {
   return React.createElement("div", null);
 };
+
+var Foo11 = function Foo11() {
+  return true && React.createElement("div", null);
+};

--- a/test/fixtures/stateless-functional-components/expected-remove-es6.js
+++ b/test/fixtures/stateless-functional-components/expected-remove-es6.js
@@ -63,3 +63,5 @@ const Foo9 = () => React.createElement("div", null);
 const Foo10 = () => {
   return React.createElement("div", null);
 };
+
+const Foo11 = () => true && <div />;

--- a/test/fixtures/stateless-functional-components/expected-wrap-es5.js
+++ b/test/fixtures/stateless-functional-components/expected-wrap-es5.js
@@ -109,3 +109,11 @@ var Foo10 = function Foo10() {
 process.env.NODE_ENV !== "production" ? Foo10.propTypes = {
   foo: React.PropTypes.string
 } : void 0;
+
+var Foo11 = function Foo11() {
+  return true && React.createElement("div", null);
+};
+
+process.env.NODE_ENV !== "production" ? Foo11.propTypes = {
+  foo: React.PropTypes.string
+} : void 0;

--- a/test/fixtures/stateless-functional-components/expected-wrap-es6.js
+++ b/test/fixtures/stateless-functional-components/expected-wrap-es6.js
@@ -103,3 +103,9 @@ const Foo10 = () => {
 process.env.NODE_ENV !== "production" ? Foo10.propTypes = {
   foo: React.PropTypes.string
 } : void 0;
+
+const Foo11 = () => true && <div />;
+
+process.env.NODE_ENV !== "production" ? Foo11.propTypes = {
+  foo: React.PropTypes.string
+} : void 0;


### PR DESCRIPTION
We are traversing the return statement deep down.
I still expect some case not being caught by this approach.
But I would rather not take them into account for now.

Closes #66.