### PR TITLE
[ES6] support extend from a global Component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,10 +26,14 @@ function isReactClass(superClass, scope) {
   } else if (superClass.node.name) { // Check for inheritance
     const className = superClass.node.name;
     const binding = scope.getBinding(className);
-    superClass = binding.path.get('superClass');
+    if (!binding) {
+      answer = false;
+    } else {
+      superClass = binding.path.get('superClass');
 
-    if (isPathReactClass(superClass)) {
-      answer = true;
+      if (isPathReactClass(superClass)) {
+        answer = true;
+      }
     }
   }
 

--- a/test/fixtures/es-class-extend-global-base-component/actual.js
+++ b/test/fixtures/es-class-extend-global-base-component/actual.js
@@ -1,0 +1,14 @@
+class Foo1 extends GlobalComponent {
+  static propTypes = {
+    foo1: React.PropTypes.string
+  };
+  render() {}
+}
+
+class Foo2 extends GlobalComponent {
+  render() {}
+}
+
+Foo2.propTypes = {
+  foo2: React.PropTypes.string
+};

--- a/test/fixtures/es-class-extend-global-base-component/expected-remove-es6.js
+++ b/test/fixtures/es-class-extend-global-base-component/expected-remove-es6.js
@@ -1,0 +1,14 @@
+class Foo1 extends GlobalComponent {
+  render() {}
+}
+
+Foo1.propTypes = {
+  foo1: React.PropTypes.string
+};
+class Foo2 extends GlobalComponent {
+  render() {}
+}
+
+Foo2.propTypes = {
+  foo2: React.PropTypes.string
+};


### PR DESCRIPTION
If extend form a Global Component (which is attached at Window), this code will be an error:

```js
const binding = scope.getBinding(className);
superClass = binding.path.get('superClass');
```

because `binding` is undefined. error message is:

```
...src/components/Header/index.js: Cannot read property 'path' of undefined
```