### PR TITLE
fix: in some conditions remove() crash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,12 @@ function remove(path, options) {
   } = options;
 
   if (mode === 'remove') {
-    path.remove();
+    // remove() crash in some conditions.
+    if (path.parentPath.type === 'ConditionalExpression') {
+      path.replaceWith(types.booleanLiteral(true));
+    } else {
+      path.remove();
+    }
   } else if (mode === 'wrap') {
     // Prevent infinity loop.
     if (path.node[visitedKey]) {
@@ -145,6 +150,7 @@ export default function ({ template, types }) {
                   wrapperIfTemplate,
                   mode,
                   type: 'createClass',
+                  types,
                 });
               }
             },
@@ -197,6 +203,7 @@ export default function ({ template, types }) {
                   wrapperIfTemplate,
                   mode,
                   type: 'class assign',
+                  types,
                 });
               }
             } else if (isStatelessComponent(binding.path)) {
@@ -205,6 +212,7 @@ export default function ({ template, types }) {
                 wrapperIfTemplate,
                 mode,
                 type: 'stateless',
+                types,
               });
             }
           },

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -25,6 +25,10 @@ describe('fixtures', () => {
       modes.forEach((mode) => {
         let expected;
 
+        // if (caseName !== 'bugfix-assignment') {
+        //   return;
+        // }
+
         // Only run the check if the expect file is provided
         try {
           expected = fs.readFileSync(path.join(fixtureDir, `expected-${mode}.js`));

--- a/test/fixtures/bugfix-assignment/actual.js
+++ b/test/fixtures/bugfix-assignment/actual.js
@@ -6,3 +6,9 @@ var App = {
     }
   },
 };
+
+const FormattedPlural = () => <div />;
+
+process.env.NODE_ENV !== 'production' ? FormattedPlural.propTypes = {
+  value: PropTypes.any.isRequired,
+} : void 0;

--- a/test/fixtures/bugfix-assignment/expected-remove-es6.js
+++ b/test/fixtures/bugfix-assignment/expected-remove-es6.js
@@ -6,3 +6,7 @@ var App = {
     }
   }
 };
+
+const FormattedPlural = () => <div />;
+
+process.env.NODE_ENV !== 'production' ? true : void 0;


### PR DESCRIPTION
The fix is inspired by this one https://github.com/babel/babili/pull/375.

Closes #76.