### PR TITLE
feat(runtime): throw on wrong pattern

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,2 +1,5 @@
 [libs]
 flow/interfaces
+
+[options]
+module.ignore_non_literal_requires=true

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "minimist": "^1.2.0",
     "mocha": "^3.2.0",
     "nodemon": "^1.11.0",
+    "path-exists": "^3.0.0",
     "pkgfiles": "^2.3.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -216,6 +216,27 @@ export default function ({ template, types }) {
               });
             }
           },
+          MemberExpression(path) {
+            const {
+              node,
+              scope,
+            } = path;
+
+            if (node.property.name === 'propTypes') {
+              const binding = scope.getBinding(node.object.name);
+
+              if (!binding) {
+                return;
+              }
+
+              if (['ImportDefaultSpecifier', 'ImportSpecifier'].indexOf(binding.path.node.type) !== -1) {
+                throw path.buildCodeFrameError(
+                  'You are accessing the propTypes from an imported Identifier.\n' +
+                  'It\'s likely to break at runtime. Instead, import the propTypes.\n' +
+                  'For more details, have a look at this issue: https://goo.gl/sHDdUk.');
+              }
+            }
+          },
         });
       },
     },

--- a/test/fixtures/wrong-pattern-1/actual.js
+++ b/test/fixtures/wrong-pattern-1/actual.js
@@ -1,0 +1,13 @@
+import { pick } from 'lodash';
+import SomeComponent1, { propTypes as someComponentPropTypes } from './SomeComponent1';
+import SomeComponent2 from './SomeComponent2';
+
+export function AnotherComponent1(props) {
+  const passedProps = pick(props, Object.keys(someComponentPropTypes));
+  return <SomeComponent1 {...passedProps} />;
+}
+
+export function AnotherComponent2(props) {
+  const passedProps = pick(props, Object.keys(SomeComponent2.propTypes));
+  return <SomeComponent2 {...passedProps} />;
+}

--- a/test/fixtures/wrong-pattern-1/options.json
+++ b/test/fixtures/wrong-pattern-1/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "You are accessing the propTypes from an imported Identifier."
+}

--- a/test/fixtures/wrong-pattern-2/actual.js
+++ b/test/fixtures/wrong-pattern-2/actual.js
@@ -1,0 +1,12 @@
+import { SomeComponent } from './SomeComponent';
+
+const propTypes = {
+  value: SomeComponent.propTypes.value,
+};
+
+export function AnotherComponent(props) {
+  return <SomeComponent value={props.value} />;
+}
+
+AnotherComponent.propTypes = propTypes;
+

--- a/test/fixtures/wrong-pattern-2/options.json
+++ b/test/fixtures/wrong-pattern-2/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "You are accessing the propTypes from an imported Identifier."
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,5 @@
+// @flow weak
+
+export function trim(str) {
+  return str.replace(/^\s+|\s+$/, '');
+}


### PR DESCRIPTION
I hope this new error won't be affected by false positive. 
We can track the number of occurrences with that [analytics](https://goo.gl/#analytics/goo.gl/sHDdUk/all_time).
The warning looks like this:

```sh
     SyntaxError: You are accessing the propTypes from an imported Identifier.
It's likely to break at runtime. Instead, import the propTypes.
For more details, have a look at this issue: https://goo.gl/sHDdUk.
    34 |
    35 | const propTypes = {
  > 36 |   value: SomeComponent.propTypes.value,
       |          ^
    37 | };
```

Closes #70