### PR TITLE
fix(class): handle class with no inheritance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,10 @@ function isPathReactClass(path) {
 }
 
 function isReactClass(superClass, scope) {
+  if (!superClass.node) {
+    return false;
+  }
+
   let answer = false;
 
   if (isPathReactClass(superClass)) {

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -20,6 +20,10 @@ describe('fixtures', () => {
     describe(`should work with ${caseName.split('-').join(' ')}`, () => {
       const fixtureDir = path.join(fixturesDir, caseName);
 
+      // if (caseName !== 'es-class-inheritance') {
+      //   return;
+      // }
+
       modes.forEach((mode) => {
         let expected;
         let options = {};

--- a/test/fixtures/es-class-inheritance/actual.js
+++ b/test/fixtures/es-class-inheritance/actual.js
@@ -17,3 +17,12 @@ class Foo2 extends PureRenderComponent {
 Foo2.propTypes = {
   foo2: PropTypes.string.isRequired,
 };
+
+// With no inheritance
+export class Foo3 {
+  static propTypes = {
+    foo3: React.PropTypes.string,
+  };
+
+  render() {}
+}

--- a/test/fixtures/es-class-inheritance/expected-remove-es5.js
+++ b/test/fixtures/es-class-inheritance/expected-remove-es5.js
@@ -1,5 +1,9 @@
 "use strict";
 
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -53,3 +57,21 @@ var Foo2 = function (_PureRenderComponent2) {
 
   return Foo2;
 }(PureRenderComponent);
+
+// With no inheritance
+var Foo3 = exports.Foo3 = function () {
+  function Foo3() {
+    _classCallCheck(this, Foo3);
+  }
+
+  _createClass(Foo3, [{
+    key: "render",
+    value: function render() {}
+  }]);
+
+  return Foo3;
+}();
+
+Foo3.propTypes = {
+  foo3: React.PropTypes.string
+};

--- a/test/fixtures/es-class-inheritance/expected-remove-es6.js
+++ b/test/fixtures/es-class-inheritance/expected-remove-es6.js
@@ -7,3 +7,12 @@ class Foo1 extends PureRenderComponent {
 class Foo2 extends PureRenderComponent {
   render() {}
 }
+
+// With no inheritance
+export class Foo3 {
+
+  render() {}
+}
+Foo3.propTypes = {
+  foo3: React.PropTypes.string
+};

--- a/test/fixtures/es-class-inheritance/expected-wrap-es5.js
+++ b/test/fixtures/es-class-inheritance/expected-wrap-es5.js
@@ -1,5 +1,9 @@
 "use strict";
 
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -61,3 +65,22 @@ var Foo2 = function (_PureRenderComponent2) {
 process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   foo2: PropTypes.string.isRequired
 } : void 0;
+
+// With no inheritance
+
+var Foo3 = exports.Foo3 = function () {
+  function Foo3() {
+    _classCallCheck(this, Foo3);
+  }
+
+  _createClass(Foo3, [{
+    key: "render",
+    value: function render() {}
+  }]);
+
+  return Foo3;
+}();
+
+Foo3.propTypes = {
+  foo3: React.PropTypes.string
+};

--- a/test/fixtures/es-class-inheritance/expected-wrap-es6.js
+++ b/test/fixtures/es-class-inheritance/expected-wrap-es6.js
@@ -14,3 +14,12 @@ class Foo2 extends PureRenderComponent {
 process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   foo2: PropTypes.string.isRequired
 } : void 0;
+
+// With no inheritance
+export class Foo3 {
+
+  render() {}
+}
+Foo3.propTypes = {
+  foo3: React.PropTypes.string
+};


### PR DESCRIPTION
This is for a very specific case on Material-UI. Most people shouldn't be affected.

Closes #85.