### PR TITLE
feat(react): support create-react-class over createClass

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,9 @@ function isPathReactClass(path) {
     return true;
   }
 
-  if ((path.node && (
-    path.node.name === 'Component' ||
-    path.node.name === 'PureComponent'
-    ))) {
+  const node = path.node;
+
+  if (node && (node.name === 'Component' || node.name === 'PureComponent')) {
     return true;
   }
 
@@ -84,7 +83,7 @@ export default function ({ template, types }) {
                   return false;
                 }
 
-                return currentNode.get('callee').matchesPattern('React.createClass');
+                return currentNode.get('callee').node.name === 'createReactClass';
               });
 
               if (parent) {

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -20,7 +20,7 @@ describe('fixtures', () => {
     describe(`should work with ${caseName.split('-').join(' ')}`, () => {
       const fixtureDir = path.join(fixturesDir, caseName);
 
-      // if (caseName !== 'es-class-inheritance') {
+      // if (caseName !== 'create-class') {
       //   return;
       // }
 

--- a/test/fixtures/create-class/actual.js
+++ b/test/fixtures/create-class/actual.js
@@ -1,5 +1,8 @@
-React.createClass({
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
+
+createReactClass({
   propTypes: {
-    foo: React.PropTypes.string,
+    foo: PropTypes.string,
   },
 });

--- a/test/fixtures/create-class/expected-remove-es6.js
+++ b/test/fixtures/create-class/expected-remove-es6.js
@@ -1,1 +1,4 @@
-React.createClass({});
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
+
+createReactClass({});


### PR DESCRIPTION
This is a breaking change, we drop support of the old `React.createClass` API to the `create-react-class` package.

In a second iteration, we could improve the logic by checking the binding to a require on the `create-react-class` package over the normalized `createReactClass` name. We will see if that worth it.

Closes #92