### PR TITLE
Remove import proptypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ For instance, you can ignore all the npm modules:
 ignoreFilenames: ['node_modules'],
 ```
 
+### `removeImport`
+ - `true`
+This removes the `import PropTypes from 'proptypes'` as well.
+This option only works if `mode` is set to `remove`
+ - `false` (default):
+Does not remove any import statements.
+
 
 ## Is it safe?
 

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ export default function ({ template, types }) {
           mode: state.opts.mode || 'remove',
           ignoreFilenames,
           types,
-          removeImport: state.opts.removeImport
+          removeImport: state.opts.removeImport,
         };
 
         // On program start, do an explicit traversal up front for this plugin.
@@ -154,18 +154,17 @@ export default function ({ template, types }) {
             }
             const { source, specifiers } = path.node;
             if (source.value !== 'prop-types') {
-              return
+              return;
             }
 
-            const usedSpecifiers = specifiers.reduce(function (usedSpecifiers, specifier) {
-
+            const usedSpecifiers = specifiers.reduce((usedSpecifiersArray, specifier) => {
               const importedIdentifierName = specifier.local.name;
               const { referencePaths } = path.scope.getBinding(importedIdentifierName);
 
               if (referencePaths.length > 0) {
-                return [...usedSpecifiers, specifier];
+                return [...usedSpecifiersArray, specifier];
               }
-              return usedSpecifiers;
+              return usedSpecifiersArray;
             }, []);
 
             if (usedSpecifiers.length === 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ export default function ({ template, types }) {
 
         programPath.scope.crawl();
 
-        if (globalOptions.removeImport) {
+        if (globalOptions.removeImport && globalOptions.mode === 'remove') {
           programPath.traverse({
             ImportDeclaration(path) {
               const { source, specifiers } = path.node;

--- a/src/index.js
+++ b/src/index.js
@@ -145,9 +145,9 @@ export default function ({ template, types }) {
           },
         });
 
-        programPath.scope.crawl();
-
         if (globalOptions.removeImport && globalOptions.mode === 'remove') {
+          programPath.scope.crawl();
+
           programPath.traverse({
             ImportDeclaration(path) {
               const { source, specifiers } = path.node;

--- a/test/fixtures/dont-remove-used-import/actual.js
+++ b/test/fixtures/dont-remove-used-import/actual.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react'
+import PropTypes from 'proptypes'
+
+export default class Greeting extends Component {
+  constructor (props, context) {
+    super(props, context)
+    const appName = context.store.getState().appName
+    this.state = {
+      appName: appName
+    }
+  }
+
+  render () {
+    return <h1>Welcome {this.props.name} to {this.state.appName}</h1>;
+  }
+}
+
+Greeting.propTypes = {
+  name: PropTypes.string.isRequired
+}
+
+Greeting.contextTypes = {
+  store: PropTypes.object
+}

--- a/test/fixtures/dont-remove-used-import/actual.js
+++ b/test/fixtures/dont-remove-used-import/actual.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'proptypes'
+import PropTypes from 'prop-types'
 
 export default class Greeting extends Component {
   constructor (props, context) {

--- a/test/fixtures/dont-remove-used-import/expected-remove-es5.js
+++ b/test/fixtures/dont-remove-used-import/expected-remove-es5.js
@@ -10,9 +10,9 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _proptypes = require('proptypes');
+var _propTypes = require('prop-types');
 
-var _proptypes2 = _interopRequireDefault(_proptypes);
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -58,5 +58,5 @@ exports.default = Greeting;
 
 
 Greeting.contextTypes = {
-  store: _proptypes2.default.object
+  store: _propTypes2.default.object
 };

--- a/test/fixtures/dont-remove-used-import/expected-remove-es5.js
+++ b/test/fixtures/dont-remove-used-import/expected-remove-es5.js
@@ -1,0 +1,62 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _proptypes = require('proptypes');
+
+var _proptypes2 = _interopRequireDefault(_proptypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Greeting = function (_Component) {
+  _inherits(Greeting, _Component);
+
+  function Greeting(props, context) {
+    _classCallCheck(this, Greeting);
+
+    var _this = _possibleConstructorReturn(this, (Greeting.__proto__ || Object.getPrototypeOf(Greeting)).call(this, props, context));
+
+    var appName = context.store.getState().appName;
+    _this.state = {
+      appName: appName
+    };
+    return _this;
+  }
+
+  _createClass(Greeting, [{
+    key: 'render',
+    value: function render() {
+      return _react2.default.createElement(
+        'h1',
+        null,
+        'Welcome ',
+        this.props.name,
+        ' to ',
+        this.state.appName
+      );
+    }
+  }]);
+
+  return Greeting;
+}(_react.Component);
+
+exports.default = Greeting;
+
+
+Greeting.contextTypes = {
+  store: _proptypes2.default.object
+};

--- a/test/fixtures/dont-remove-used-import/expected-remove-es6.js
+++ b/test/fixtures/dont-remove-used-import/expected-remove-es6.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+import PropTypes from 'proptypes';
+
+export default class Greeting extends Component {
+  constructor(props, context) {
+    super(props, context);
+    const appName = context.store.getState().appName;
+    this.state = {
+      appName: appName
+    };
+  }
+
+  render() {
+    return <h1>Welcome {this.props.name} to {this.state.appName}</h1>;
+  }
+}
+
+Greeting.contextTypes = {
+  store: PropTypes.object
+};

--- a/test/fixtures/dont-remove-used-import/expected-remove-es6.js
+++ b/test/fixtures/dont-remove-used-import/expected-remove-es6.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import PropTypes from 'proptypes';
+import PropTypes from 'prop-types';
 
 export default class Greeting extends Component {
   constructor(props, context) {

--- a/test/fixtures/dont-remove-used-import/options.json
+++ b/test/fixtures/dont-remove-used-import/options.json
@@ -1,0 +1,3 @@
+{
+  "removeImport": true
+}

--- a/test/fixtures/remove-import-proptypes/actual.js
+++ b/test/fixtures/remove-import-proptypes/actual.js
@@ -1,0 +1,12 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+class Greeting extends Component {
+  render() {
+    return <h1>Hello, {this.props.name}</h1>;
+  }
+}
+
+Greeting.propTypes = {
+  name: PropTypes.string
+};

--- a/test/fixtures/remove-import-proptypes/expected-remove-es5.js
+++ b/test/fixtures/remove-import-proptypes/expected-remove-es5.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Greeting = function (_Component) {
+  _inherits(Greeting, _Component);
+
+  function Greeting() {
+    _classCallCheck(this, Greeting);
+
+    return _possibleConstructorReturn(this, (Greeting.__proto__ || Object.getPrototypeOf(Greeting)).apply(this, arguments));
+  }
+
+  _createClass(Greeting, [{
+    key: 'render',
+    value: function render() {
+      return _react2.default.createElement(
+        'h1',
+        null,
+        'Hello, ',
+        this.props.name
+      );
+    }
+  }]);
+
+  return Greeting;
+}(_react.Component);

--- a/test/fixtures/remove-import-proptypes/expected-remove-es6.js
+++ b/test/fixtures/remove-import-proptypes/expected-remove-es6.js
@@ -1,0 +1,7 @@
+import React, { Component } from 'react';
+
+class Greeting extends Component {
+  render() {
+    return <h1>Hello, {this.props.name}</h1>;
+  }
+}

--- a/test/fixtures/remove-import-proptypes/expected-remove-es6.js
+++ b/test/fixtures/remove-import-proptypes/expected-remove-es6.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 
+
 class Greeting extends Component {
   render() {
     return <h1>Hello, {this.props.name}</h1>;

--- a/test/fixtures/remove-import-proptypes/options.json
+++ b/test/fixtures/remove-import-proptypes/options.json
@@ -1,0 +1,3 @@
+{
+  "removeImport": true
+}


### PR DESCRIPTION
Closes https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/issues/89

Its opt-in, takes a key `removeImport: true` to remove imports.
Does not remove if the specifier is used.

Do let me know if any lint fixes or other changes you would like me to make.

CC: @kentcdodds