### PR TITLE
Add contextMode option to wrap or remove contextTypes and childContextTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ import PropTypes from 'prop-types'
 ```
  - `false` (default): does not remove the import statements.
 
+### `contextMode`
+
+:warning: **Use this option only if you are using the React `context` API, and you know what you're doing.** :warning: 
+ - `ignore` (default):
+Will not include `contextTypes` and `childContextTypes` to the definitions to remove or wrap.
+ - `wrap`:
+The `contextTypes` and `childContextTypes` definitions are wrapped with the following code:
+```js
+if (process.env.NODE_ENV !== "production") {
+  // ...
+}
+```
+This is the recommended mode for libraries targeting React ecosystem.
+ - `remove`:
+The `contextTypes` and `childContextTypes` definitions are removed from the source code.
+
+This mode should only be used if you are targeting framework like Preact, which implements context without contextTypes and childContextTypes.
+
 ### `ignoreFilenames`
 
 This filter generates a regular expression.

--- a/src/remove.js
+++ b/src/remove.js
@@ -19,7 +19,6 @@ export default function remove(path, globalOptions, options) {
   const {
     visitedKey,
     wrapperIfTemplate,
-    mode,
     ignoreFilenames,
     types,
   } = globalOptions;
@@ -28,14 +27,14 @@ export default function remove(path, globalOptions, options) {
     return;
   }
 
-  if (mode === 'remove') {
+  if (options.mode === 'remove') {
     // remove() crash in some conditions.
     if (path.parentPath.type === 'ConditionalExpression') {
       path.replaceWith(types.unaryExpression('void', types.numericLiteral(0)));
     } else {
       path.remove();
     }
-  } else if (mode === 'wrap') {
+  } else if (options.mode === 'wrap') {
     // Prevent infinity loop.
     if (path.node[visitedKey]) {
       return;
@@ -87,6 +86,6 @@ export default function remove(path, globalOptions, options) {
         break;
     }
   } else {
-    throw new Error(`transform-react-remove-prop-type: unsupported mode ${mode}.`);
+    throw new Error(`transform-react-remove-prop-type: unsupported mode ${options.mode}.`);
   }
 }

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -11,7 +11,8 @@ import babelPluginTransformClassProperties from 'babel-plugin-transform-class-pr
 import babelPluginTransformReactRemovePropTypes from '../src/index';
 import { trim } from './utils';
 
-const modes = ['remove-es5', 'wrap-es5', 'remove-es6', 'wrap-es6'];
+const modes = ['remove-es5', 'wrap-es5', 'remove-es6', 'wrap-es6', 'remove-context-wrap-es6',
+  'remove-context-remove-es6', 'wrap-context-wrap-es6', 'wrap-context-remove-es6'];
 
 describe('fixtures', () => {
   const fixturesDir = path.join(__dirname, 'fixtures');
@@ -92,7 +93,78 @@ describe('fixtures', () => {
               };
               break;
 
+            case 'remove-context-wrap-es6':
+              babelConfig = {
+                babelrc: false,
+                plugins: [
+                  babelPluginSyntaxJsx,
+                  babelPluginTransformClassProperties,
+                  [
+                    babelPluginTransformReactRemovePropTypes,
+                    {
+                      ...options,
+                      mode: 'remove',
+                      contextMode: 'wrap',
+                    },
+                  ],
+                ],
+              };
+              break;
+
+            case 'remove-context-remove-es6':
+              babelConfig = {
+                babelrc: false,
+                plugins: [
+                  babelPluginSyntaxJsx,
+                  babelPluginTransformClassProperties,
+                  [
+                    babelPluginTransformReactRemovePropTypes,
+                    {
+                      ...options,
+                      mode: 'remove',
+                      contextMode: 'remove',
+                    },
+                  ],
+                ],
+              };
+              break;
+
             case 'wrap-es6':
+              babelConfig = {
+                babelrc: false,
+                plugins: [
+                  babelPluginSyntaxJsx,
+                  babelPluginTransformClassProperties,
+                  [
+                    babelPluginTransformReactRemovePropTypes,
+                    {
+                      ...options,
+                      mode: 'wrap',
+                    },
+                  ],
+                ],
+              };
+              break;
+
+            case 'wrap-context-wrap-es6':
+              babelConfig = {
+                babelrc: false,
+                plugins: [
+                  babelPluginSyntaxJsx,
+                  babelPluginTransformClassProperties,
+                  [
+                    babelPluginTransformReactRemovePropTypes,
+                    {
+                      ...options,
+                      mode: 'wrap',
+                      contextMode: 'wrap',
+                    },
+                  ],
+                ],
+              };
+              break;
+
+            case 'wrap-context-remove-es6':
             default:
               babelConfig = {
                 babelrc: false,
@@ -104,6 +176,7 @@ describe('fixtures', () => {
                     {
                       ...options,
                       mode: 'wrap',
+                      contextMode: 'remove',
                     },
                   ],
                 ],

--- a/test/fixtures/es-class-assign-property/actual.js
+++ b/test/fixtures/es-class-assign-property/actual.js
@@ -6,10 +6,26 @@ Foo1.propTypes = {
   bar1: PropTypes.string,
 };
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string,
+};
+
+Foo1.childContextTypes = {
+  bar1: PropTypes.string,
+};
+
 class Foo2 extends React.PureComponent {
   render() {}
 }
 
 Foo2.propTypes = {
+  bar2: PropTypes.string,
+};
+
+Foo1.contextTypes = {
+  bar2: PropTypes.string,
+};
+
+Foo1.childContextTypes = {
   bar2: PropTypes.string,
 };

--- a/test/fixtures/es-class-assign-property/actual.js
+++ b/test/fixtures/es-class-assign-property/actual.js
@@ -22,10 +22,10 @@ Foo2.propTypes = {
   bar2: PropTypes.string,
 };
 
-Foo1.contextTypes = {
+Foo2.contextTypes = {
   bar2: PropTypes.string,
 };
 
-Foo1.childContextTypes = {
+Foo2.childContextTypes = {
   bar2: PropTypes.string,
 };

--- a/test/fixtures/es-class-assign-property/expected-remove-context-remove-es6.js
+++ b/test/fixtures/es-class-assign-property/expected-remove-context-remove-es6.js
@@ -1,0 +1,7 @@
+class Foo1 extends React.Component {
+  render() {}
+}
+
+class Foo2 extends React.PureComponent {
+  render() {}
+}

--- a/test/fixtures/es-class-assign-property/expected-remove-context-wrap-es6.js
+++ b/test/fixtures/es-class-assign-property/expected-remove-context-wrap-es6.js
@@ -14,10 +14,10 @@ class Foo2 extends React.PureComponent {
   render() {}
 }
 
-process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+process.env.NODE_ENV !== "production" ? Foo2.contextTypes = {
   bar2: PropTypes.string
 } : void 0;
 
-process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+process.env.NODE_ENV !== "production" ? Foo2.childContextTypes = {
   bar2: PropTypes.string
 } : void 0;

--- a/test/fixtures/es-class-assign-property/expected-remove-context-wrap-es6.js
+++ b/test/fixtures/es-class-assign-property/expected-remove-context-wrap-es6.js
@@ -1,0 +1,23 @@
+class Foo1 extends React.Component {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+
+class Foo2 extends React.PureComponent {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+  bar2: PropTypes.string
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  bar2: PropTypes.string
+} : void 0;

--- a/test/fixtures/es-class-assign-property/expected-remove-es5.js
+++ b/test/fixtures/es-class-assign-property/expected-remove-es5.js
@@ -25,6 +25,14 @@ var Foo1 = function (_React$Component) {
   return Foo1;
 }(React.Component);
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
+
 var Foo2 = function (_React$PureComponent) {
   _inherits(Foo2, _React$PureComponent);
 
@@ -41,3 +49,11 @@ var Foo2 = function (_React$PureComponent) {
 
   return Foo2;
 }(React.PureComponent);
+
+Foo1.contextTypes = {
+  bar2: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar2: PropTypes.string
+};

--- a/test/fixtures/es-class-assign-property/expected-remove-es5.js
+++ b/test/fixtures/es-class-assign-property/expected-remove-es5.js
@@ -50,10 +50,10 @@ var Foo2 = function (_React$PureComponent) {
   return Foo2;
 }(React.PureComponent);
 
-Foo1.contextTypes = {
+Foo2.contextTypes = {
   bar2: PropTypes.string
 };
 
-Foo1.childContextTypes = {
+Foo2.childContextTypes = {
   bar2: PropTypes.string
 };

--- a/test/fixtures/es-class-assign-property/expected-remove-es6.js
+++ b/test/fixtures/es-class-assign-property/expected-remove-es6.js
@@ -2,6 +2,22 @@ class Foo1 extends React.Component {
   render() {}
 }
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
+
 class Foo2 extends React.PureComponent {
   render() {}
 }
+
+Foo1.contextTypes = {
+  bar2: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar2: PropTypes.string
+};

--- a/test/fixtures/es-class-assign-property/expected-remove-es6.js
+++ b/test/fixtures/es-class-assign-property/expected-remove-es6.js
@@ -14,10 +14,10 @@ class Foo2 extends React.PureComponent {
   render() {}
 }
 
-Foo1.contextTypes = {
+Foo2.contextTypes = {
   bar2: PropTypes.string
 };
 
-Foo1.childContextTypes = {
+Foo2.childContextTypes = {
   bar2: PropTypes.string
 };

--- a/test/fixtures/es-class-assign-property/expected-wrap-context-remove-es6.js
+++ b/test/fixtures/es-class-assign-property/expected-wrap-context-remove-es6.js
@@ -1,0 +1,15 @@
+class Foo1 extends React.Component {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
+  bar1: PropTypes.string
+} : void 0;
+
+class Foo2 extends React.PureComponent {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
+  bar2: PropTypes.string
+} : void 0;

--- a/test/fixtures/es-class-assign-property/expected-wrap-context-wrap-es6.js
+++ b/test/fixtures/es-class-assign-property/expected-wrap-context-wrap-es6.js
@@ -1,0 +1,31 @@
+class Foo1 extends React.Component {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
+  bar1: PropTypes.string
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+
+class Foo2 extends React.PureComponent {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
+  bar2: PropTypes.string
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+  bar2: PropTypes.string
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  bar2: PropTypes.string
+} : void 0;

--- a/test/fixtures/es-class-assign-property/expected-wrap-context-wrap-es6.js
+++ b/test/fixtures/es-class-assign-property/expected-wrap-context-wrap-es6.js
@@ -22,10 +22,10 @@ process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   bar2: PropTypes.string
 } : void 0;
 
-process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+process.env.NODE_ENV !== "production" ? Foo2.contextTypes = {
   bar2: PropTypes.string
 } : void 0;
 
-process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+process.env.NODE_ENV !== "production" ? Foo2.childContextTypes = {
   bar2: PropTypes.string
 } : void 0;

--- a/test/fixtures/es-class-assign-property/expected-wrap-es5.js
+++ b/test/fixtures/es-class-assign-property/expected-wrap-es5.js
@@ -29,6 +29,14 @@ process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
   bar1: PropTypes.string
 } : void 0;
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
+
 var Foo2 = function (_React$PureComponent) {
   _inherits(Foo2, _React$PureComponent);
 
@@ -49,3 +57,11 @@ var Foo2 = function (_React$PureComponent) {
 process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   bar2: PropTypes.string
 } : void 0;
+
+Foo1.contextTypes = {
+  bar2: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar2: PropTypes.string
+};

--- a/test/fixtures/es-class-assign-property/expected-wrap-es5.js
+++ b/test/fixtures/es-class-assign-property/expected-wrap-es5.js
@@ -58,10 +58,10 @@ process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   bar2: PropTypes.string
 } : void 0;
 
-Foo1.contextTypes = {
+Foo2.contextTypes = {
   bar2: PropTypes.string
 };
 
-Foo1.childContextTypes = {
+Foo2.childContextTypes = {
   bar2: PropTypes.string
 };

--- a/test/fixtures/es-class-assign-property/expected-wrap-es6.js
+++ b/test/fixtures/es-class-assign-property/expected-wrap-es6.js
@@ -22,10 +22,10 @@ process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   bar2: PropTypes.string
 } : void 0;
 
-Foo1.contextTypes = {
+Foo2.contextTypes = {
   bar2: PropTypes.string
 };
 
-Foo1.childContextTypes = {
+Foo2.childContextTypes = {
   bar2: PropTypes.string
 };

--- a/test/fixtures/es-class-assign-property/expected-wrap-es6.js
+++ b/test/fixtures/es-class-assign-property/expected-wrap-es6.js
@@ -6,6 +6,14 @@ process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
   bar1: PropTypes.string
 } : void 0;
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
+
 class Foo2 extends React.PureComponent {
   render() {}
 }
@@ -13,3 +21,11 @@ class Foo2 extends React.PureComponent {
 process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   bar2: PropTypes.string
 } : void 0;
+
+Foo1.contextTypes = {
+  bar2: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar2: PropTypes.string
+};

--- a/test/fixtures/es-class-extend-component/actual.js
+++ b/test/fixtures/es-class-extend-component/actual.js
@@ -3,6 +3,13 @@ class Foo1 extends Component {
     foo1: PropTypes.string,
   };
 
+  static contextTypes = {
+    bar1: PropTypes.string,
+  };
+
+  static childContextTypes = {
+    bar1: PropTypes.string,
+  };
   render() {}
 }
 
@@ -12,4 +19,12 @@ class Foo2 extends Component {
 
 Foo2.propTypes = {
   foo2: PropTypes.string,
+};
+
+Foo2.contextTypes = {
+  bar2: PropTypes.string,
+};
+
+Foo1.childContextTypes = {
+  bar2: PropTypes.string,
 };

--- a/test/fixtures/es-class-extend-component/expected-remove-context-remove-es6.js
+++ b/test/fixtures/es-class-extend-component/expected-remove-context-remove-es6.js
@@ -1,0 +1,7 @@
+class Foo1 extends Component {
+  render() {}
+}
+
+class Foo2 extends Component {
+  render() {}
+}

--- a/test/fixtures/es-class-extend-component/expected-remove-context-wrap-es6.js
+++ b/test/fixtures/es-class-extend-component/expected-remove-context-wrap-es6.js
@@ -1,0 +1,21 @@
+class Foo1 extends Component {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+class Foo2 extends Component {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo2.contextTypes = {
+  bar2: PropTypes.string
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  bar2: PropTypes.string
+} : void 0;

--- a/test/fixtures/es-class-extend-component/expected-remove-es5.js
+++ b/test/fixtures/es-class-extend-component/expected-remove-es5.js
@@ -25,6 +25,13 @@ var Foo1 = function (_Component) {
   return Foo1;
 }(Component);
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
+
 var Foo2 = function (_Component2) {
   _inherits(Foo2, _Component2);
 
@@ -41,3 +48,11 @@ var Foo2 = function (_Component2) {
 
   return Foo2;
 }(Component);
+
+Foo2.contextTypes = {
+  bar2: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar2: PropTypes.string
+};

--- a/test/fixtures/es-class-extend-component/expected-remove-es6.js
+++ b/test/fixtures/es-class-extend-component/expected-remove-es6.js
@@ -1,8 +1,21 @@
 class Foo1 extends Component {
-
   render() {}
 }
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
 class Foo2 extends Component {
   render() {}
 }
+
+Foo2.contextTypes = {
+  bar2: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar2: PropTypes.string
+};

--- a/test/fixtures/es-class-extend-component/expected-wrap-context-remove-es6.js
+++ b/test/fixtures/es-class-extend-component/expected-wrap-context-remove-es6.js
@@ -1,0 +1,14 @@
+class Foo1 extends Component {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
+  foo1: PropTypes.string
+} : void 0;
+class Foo2 extends Component {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
+  foo2: PropTypes.string
+} : void 0;

--- a/test/fixtures/es-class-extend-component/expected-wrap-context-wrap-es6.js
+++ b/test/fixtures/es-class-extend-component/expected-wrap-context-wrap-es6.js
@@ -1,0 +1,28 @@
+class Foo1 extends Component {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
+  foo1: PropTypes.string
+} : void 0;
+class Foo2 extends Component {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
+  foo2: PropTypes.string
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo2.contextTypes = {
+  bar2: PropTypes.string
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  bar2: PropTypes.string
+} : void 0;

--- a/test/fixtures/es-class-extend-component/expected-wrap-es5.js
+++ b/test/fixtures/es-class-extend-component/expected-wrap-es5.js
@@ -25,6 +25,12 @@ var Foo1 = function (_Component) {
   return Foo1;
 }(Component);
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
 process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
   foo1: PropTypes.string
 } : void 0;
@@ -49,3 +55,11 @@ var Foo2 = function (_Component2) {
 process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   foo2: PropTypes.string
 } : void 0;
+
+Foo2.contextTypes = {
+  bar2: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar2: PropTypes.string
+};

--- a/test/fixtures/es-class-extend-component/expected-wrap-es6.js
+++ b/test/fixtures/es-class-extend-component/expected-wrap-es6.js
@@ -1,8 +1,13 @@
 class Foo1 extends Component {
-
   render() {}
 }
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
 process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
   foo1: PropTypes.string
 } : void 0;
@@ -13,3 +18,11 @@ class Foo2 extends Component {
 process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   foo2: PropTypes.string
 } : void 0;
+
+Foo2.contextTypes = {
+  bar2: PropTypes.string
+};
+
+Foo1.childContextTypes = {
+  bar2: PropTypes.string
+};

--- a/test/fixtures/es-class-inheritance/actual.js
+++ b/test/fixtures/es-class-inheritance/actual.js
@@ -5,6 +5,15 @@ class Foo1 extends PureRenderComponent {
   static propTypes = {
     foo1: PropTypes.string.isRequired,
   };
+
+  static contextTypes = {
+    foo1: PropTypes.string.isRequired,
+  };
+
+  static childContextTypes = {
+    foo1: PropTypes.string.isRequired,
+  };
+
   render() {
   }
 }
@@ -18,9 +27,25 @@ Foo2.propTypes = {
   foo2: PropTypes.string.isRequired,
 };
 
+Foo2.contextTypes = {
+  foo2: PropTypes.string.isRequired,
+};
+
+Foo2.childContextTypes = {
+  foo2: PropTypes.string.isRequired,
+};
+
 // With no inheritance
 export class Foo3 {
   static propTypes = {
+    foo3: PropTypes.string,
+  };
+
+  static contextTypes = {
+    foo3: PropTypes.string,
+  };
+
+  static childContextTypes = {
     foo3: PropTypes.string,
   };
 

--- a/test/fixtures/es-class-inheritance/expected-remove-context-remove-es6.js
+++ b/test/fixtures/es-class-inheritance/expected-remove-context-remove-es6.js
@@ -1,0 +1,25 @@
+class PureRenderComponent extends Component {}
+
+class Foo1 extends PureRenderComponent {
+
+  render() {}
+}
+
+class Foo2 extends PureRenderComponent {
+  render() {}
+}
+
+// With no inheritance
+export class Foo3 {
+
+  render() {}
+}
+Foo3.propTypes = {
+  foo3: PropTypes.string
+};
+Foo3.contextTypes = {
+  foo3: PropTypes.string
+};
+Foo3.childContextTypes = {
+  foo3: PropTypes.string
+};

--- a/test/fixtures/es-class-inheritance/expected-remove-context-wrap-es6.js
+++ b/test/fixtures/es-class-inheritance/expected-remove-context-wrap-es6.js
@@ -1,0 +1,39 @@
+class PureRenderComponent extends Component {}
+
+class Foo1 extends PureRenderComponent {
+
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  foo1: PropTypes.string.isRequired
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+  foo1: PropTypes.string.isRequired
+} : void 0;
+class Foo2 extends PureRenderComponent {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo2.contextTypes = {
+  foo2: PropTypes.string.isRequired
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo2.childContextTypes = {
+  foo2: PropTypes.string.isRequired
+} : void 0;
+
+// With no inheritance
+export class Foo3 {
+
+  render() {}
+}
+Foo3.propTypes = {
+  foo3: PropTypes.string
+};
+Foo3.contextTypes = {
+  foo3: PropTypes.string
+};
+Foo3.childContextTypes = {
+  foo3: PropTypes.string
+};

--- a/test/fixtures/es-class-inheritance/expected-remove-es5.js
+++ b/test/fixtures/es-class-inheritance/expected-remove-es5.js
@@ -41,6 +41,13 @@ var Foo1 = function (_PureRenderComponent) {
   return Foo1;
 }(PureRenderComponent);
 
+Foo1.contextTypes = {
+  foo1: PropTypes.string.isRequired
+};
+Foo1.childContextTypes = {
+  foo1: PropTypes.string.isRequired
+};
+
 var Foo2 = function (_PureRenderComponent2) {
   _inherits(Foo2, _PureRenderComponent2);
 
@@ -58,7 +65,16 @@ var Foo2 = function (_PureRenderComponent2) {
   return Foo2;
 }(PureRenderComponent);
 
+Foo2.contextTypes = {
+  foo2: PropTypes.string.isRequired
+};
+
+Foo2.childContextTypes = {
+  foo2: PropTypes.string.isRequired
+};
+
 // With no inheritance
+
 var Foo3 = exports.Foo3 = function () {
   function Foo3() {
     _classCallCheck(this, Foo3);
@@ -73,5 +89,11 @@ var Foo3 = exports.Foo3 = function () {
 }();
 
 Foo3.propTypes = {
+  foo3: PropTypes.string
+};
+Foo3.contextTypes = {
+  foo3: PropTypes.string
+};
+Foo3.childContextTypes = {
   foo3: PropTypes.string
 };

--- a/test/fixtures/es-class-inheritance/expected-remove-es6.js
+++ b/test/fixtures/es-class-inheritance/expected-remove-es6.js
@@ -1,12 +1,27 @@
 class PureRenderComponent extends Component {}
 
 class Foo1 extends PureRenderComponent {
+
   render() {}
 }
 
+Foo1.contextTypes = {
+  foo1: PropTypes.string.isRequired
+};
+Foo1.childContextTypes = {
+  foo1: PropTypes.string.isRequired
+};
 class Foo2 extends PureRenderComponent {
   render() {}
 }
+
+Foo2.contextTypes = {
+  foo2: PropTypes.string.isRequired
+};
+
+Foo2.childContextTypes = {
+  foo2: PropTypes.string.isRequired
+};
 
 // With no inheritance
 export class Foo3 {
@@ -14,5 +29,11 @@ export class Foo3 {
   render() {}
 }
 Foo3.propTypes = {
+  foo3: PropTypes.string
+};
+Foo3.contextTypes = {
+  foo3: PropTypes.string
+};
+Foo3.childContextTypes = {
   foo3: PropTypes.string
 };

--- a/test/fixtures/es-class-inheritance/expected-wrap-context-remove-es6.js
+++ b/test/fixtures/es-class-inheritance/expected-wrap-context-remove-es6.js
@@ -1,0 +1,32 @@
+class PureRenderComponent extends Component {}
+
+class Foo1 extends PureRenderComponent {
+
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
+  foo1: PropTypes.string.isRequired
+} : void 0;
+class Foo2 extends PureRenderComponent {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
+  foo2: PropTypes.string.isRequired
+} : void 0;
+
+// With no inheritance
+export class Foo3 {
+
+  render() {}
+}
+Foo3.propTypes = {
+  foo3: PropTypes.string
+};
+Foo3.contextTypes = {
+  foo3: PropTypes.string
+};
+Foo3.childContextTypes = {
+  foo3: PropTypes.string
+};

--- a/test/fixtures/es-class-inheritance/expected-wrap-context-wrap-es6.js
+++ b/test/fixtures/es-class-inheritance/expected-wrap-context-wrap-es6.js
@@ -1,0 +1,46 @@
+class PureRenderComponent extends Component {}
+
+class Foo1 extends PureRenderComponent {
+
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  foo1: PropTypes.string.isRequired
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+  foo1: PropTypes.string.isRequired
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
+  foo1: PropTypes.string.isRequired
+} : void 0;
+class Foo2 extends PureRenderComponent {
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
+  foo2: PropTypes.string.isRequired
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo2.contextTypes = {
+  foo2: PropTypes.string.isRequired
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Foo2.childContextTypes = {
+  foo2: PropTypes.string.isRequired
+} : void 0;
+
+// With no inheritance
+export class Foo3 {
+
+  render() {}
+}
+Foo3.propTypes = {
+  foo3: PropTypes.string
+};
+Foo3.contextTypes = {
+  foo3: PropTypes.string
+};
+Foo3.childContextTypes = {
+  foo3: PropTypes.string
+};

--- a/test/fixtures/es-class-inheritance/expected-wrap-es5.js
+++ b/test/fixtures/es-class-inheritance/expected-wrap-es5.js
@@ -41,6 +41,12 @@ var Foo1 = function (_PureRenderComponent) {
   return Foo1;
 }(PureRenderComponent);
 
+Foo1.contextTypes = {
+  foo1: PropTypes.string.isRequired
+};
+Foo1.childContextTypes = {
+  foo1: PropTypes.string.isRequired
+};
 process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
   foo1: PropTypes.string.isRequired
 } : void 0;
@@ -66,6 +72,14 @@ process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   foo2: PropTypes.string.isRequired
 } : void 0;
 
+Foo2.contextTypes = {
+  foo2: PropTypes.string.isRequired
+};
+
+Foo2.childContextTypes = {
+  foo2: PropTypes.string.isRequired
+};
+
 // With no inheritance
 
 var Foo3 = exports.Foo3 = function () {
@@ -82,5 +96,11 @@ var Foo3 = exports.Foo3 = function () {
 }();
 
 Foo3.propTypes = {
+  foo3: PropTypes.string
+};
+Foo3.contextTypes = {
+  foo3: PropTypes.string
+};
+Foo3.childContextTypes = {
   foo3: PropTypes.string
 };

--- a/test/fixtures/es-class-inheritance/expected-wrap-es6.js
+++ b/test/fixtures/es-class-inheritance/expected-wrap-es6.js
@@ -1,9 +1,16 @@
 class PureRenderComponent extends Component {}
 
 class Foo1 extends PureRenderComponent {
+
   render() {}
 }
 
+Foo1.contextTypes = {
+  foo1: PropTypes.string.isRequired
+};
+Foo1.childContextTypes = {
+  foo1: PropTypes.string.isRequired
+};
 process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
   foo1: PropTypes.string.isRequired
 } : void 0;
@@ -15,11 +22,25 @@ process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   foo2: PropTypes.string.isRequired
 } : void 0;
 
+Foo2.contextTypes = {
+  foo2: PropTypes.string.isRequired
+};
+
+Foo2.childContextTypes = {
+  foo2: PropTypes.string.isRequired
+};
+
 // With no inheritance
 export class Foo3 {
 
   render() {}
 }
 Foo3.propTypes = {
+  foo3: PropTypes.string
+};
+Foo3.contextTypes = {
+  foo3: PropTypes.string
+};
+Foo3.childContextTypes = {
   foo3: PropTypes.string
 };

--- a/test/fixtures/es-class-no-name/actual.js
+++ b/test/fixtures/es-class-no-name/actual.js
@@ -3,5 +3,13 @@ export default class extends React.Component {
     foo: PropTypes.string,
   };
 
+  static contextTypes = {
+    foo: PropTypes.string.isRequired,
+  };
+
+  static childContextTypes = {
+    foo: PropTypes.string.isRequired,
+  };
+
   render() {}
 }

--- a/test/fixtures/es-class-no-name/expected-remove-context-remove-es6.js
+++ b/test/fixtures/es-class-no-name/expected-remove-context-remove-es6.js
@@ -1,0 +1,4 @@
+export default class extends React.Component {
+
+  render() {}
+}

--- a/test/fixtures/es-class-no-name/expected-remove-context-wrap-es6.js
+++ b/test/fixtures/es-class-no-name/expected-remove-context-wrap-es6.js
@@ -1,0 +1,10 @@
+export default class _class extends React.Component {
+
+  render() {}
+}
+_class.contextTypes = {
+  foo: PropTypes.string.isRequired
+};
+_class.childContextTypes = {
+  foo: PropTypes.string.isRequired
+};

--- a/test/fixtures/es-class-no-name/expected-remove-es5.js
+++ b/test/fixtures/es-class-no-name/expected-remove-es5.js
@@ -29,4 +29,10 @@ var _class = function (_React$Component) {
   return _class;
 }(React.Component);
 
+_class.contextTypes = {
+  foo: PropTypes.string.isRequired
+};
+_class.childContextTypes = {
+  foo: PropTypes.string.isRequired
+};
 exports.default = _class;

--- a/test/fixtures/es-class-no-name/expected-remove-es6.js
+++ b/test/fixtures/es-class-no-name/expected-remove-es6.js
@@ -1,4 +1,10 @@
-export default class extends React.Component {
+export default class _class extends React.Component {
 
   render() {}
 }
+_class.contextTypes = {
+  foo: PropTypes.string.isRequired
+};
+_class.childContextTypes = {
+  foo: PropTypes.string.isRequired
+};

--- a/test/fixtures/es-class-no-name/expected-wrap-context-remove-es6.js
+++ b/test/fixtures/es-class-no-name/expected-wrap-context-remove-es6.js
@@ -1,0 +1,7 @@
+export default class _class extends React.Component {
+
+  render() {}
+}
+_class.propTypes = {
+  foo: PropTypes.string
+};

--- a/test/fixtures/es-class-no-name/expected-wrap-context-wrap-es6.js
+++ b/test/fixtures/es-class-no-name/expected-wrap-context-wrap-es6.js
@@ -1,0 +1,13 @@
+export default class _class extends React.Component {
+
+  render() {}
+}
+_class.propTypes = {
+  foo: PropTypes.string
+};
+_class.contextTypes = {
+  foo: PropTypes.string.isRequired
+};
+_class.childContextTypes = {
+  foo: PropTypes.string.isRequired
+};

--- a/test/fixtures/es-class-no-name/expected-wrap-es5.js
+++ b/test/fixtures/es-class-no-name/expected-wrap-es5.js
@@ -32,4 +32,10 @@ var _class = function (_React$Component) {
 _class.propTypes = {
   foo: PropTypes.string
 };
+_class.contextTypes = {
+  foo: PropTypes.string.isRequired
+};
+_class.childContextTypes = {
+  foo: PropTypes.string.isRequired
+};
 exports.default = _class;

--- a/test/fixtures/es-class-no-name/expected-wrap-es6.js
+++ b/test/fixtures/es-class-no-name/expected-wrap-es6.js
@@ -5,3 +5,9 @@ export default class _class extends React.Component {
 _class.propTypes = {
   foo: PropTypes.string
 };
+_class.contextTypes = {
+  foo: PropTypes.string.isRequired
+};
+_class.childContextTypes = {
+  foo: PropTypes.string.isRequired
+};

--- a/test/fixtures/es-class-static-property/actual.js
+++ b/test/fixtures/es-class-static-property/actual.js
@@ -3,11 +3,27 @@ class Foo1 extends React.Component {
     bar1: PropTypes.string,
   };
 
+  static contextTypes = {
+    bar1: PropTypes.string,
+  };
+
+  static childContextTypes = {
+    bar1: PropTypes.string,
+  };
+
   render() {}
 }
 
 export default class Foo2 extends React.Component {
   static propTypes = {
+    bar2: PropTypes.string,
+  };
+
+  static contextTypes = {
+    bar2: PropTypes.string,
+  };
+  
+  static childContextTypes = {
     bar2: PropTypes.string,
   };
 

--- a/test/fixtures/es-class-static-property/expected-remove-context-remove-es6.js
+++ b/test/fixtures/es-class-static-property/expected-remove-context-remove-es6.js
@@ -1,0 +1,9 @@
+class Foo1 extends React.Component {
+
+  render() {}
+}
+
+export default class Foo2 extends React.Component {
+
+  render() {}
+}

--- a/test/fixtures/es-class-static-property/expected-remove-context-wrap-es6.js
+++ b/test/fixtures/es-class-static-property/expected-remove-context-wrap-es6.js
@@ -1,0 +1,21 @@
+class Foo1 extends React.Component {
+
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+export default class Foo2 extends React.Component {
+
+  render() {}
+}
+process.env.NODE_ENV !== "production" ? Foo2.childContextTypes = {
+  bar2: PropTypes.string
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo2.contextTypes = {
+  bar2: PropTypes.string
+} : void 0;

--- a/test/fixtures/es-class-static-property/expected-remove-es5.js
+++ b/test/fixtures/es-class-static-property/expected-remove-es5.js
@@ -29,6 +29,13 @@ var Foo1 = function (_React$Component) {
   return Foo1;
 }(React.Component);
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
+
 var Foo2 = function (_React$Component2) {
   _inherits(Foo2, _React$Component2);
 
@@ -46,4 +53,10 @@ var Foo2 = function (_React$Component2) {
   return Foo2;
 }(React.Component);
 
+Foo2.contextTypes = {
+  bar2: PropTypes.string
+};
+Foo2.childContextTypes = {
+  bar2: PropTypes.string
+};
 exports.default = Foo2;

--- a/test/fixtures/es-class-static-property/expected-remove-es6.js
+++ b/test/fixtures/es-class-static-property/expected-remove-es6.js
@@ -3,7 +3,19 @@ class Foo1 extends React.Component {
   render() {}
 }
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
 export default class Foo2 extends React.Component {
 
   render() {}
 }
+Foo2.contextTypes = {
+  bar2: PropTypes.string
+};
+Foo2.childContextTypes = {
+  bar2: PropTypes.string
+};

--- a/test/fixtures/es-class-static-property/expected-wrap-context-remove-es6.js
+++ b/test/fixtures/es-class-static-property/expected-wrap-context-remove-es6.js
@@ -1,0 +1,15 @@
+class Foo1 extends React.Component {
+
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
+  bar1: PropTypes.string
+} : void 0;
+export default class Foo2 extends React.Component {
+
+  render() {}
+}
+process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
+  bar2: PropTypes.string
+} : void 0;

--- a/test/fixtures/es-class-static-property/expected-wrap-context-wrap-es6.js
+++ b/test/fixtures/es-class-static-property/expected-wrap-context-wrap-es6.js
@@ -1,0 +1,27 @@
+class Foo1 extends React.Component {
+
+  render() {}
+}
+
+process.env.NODE_ENV !== "production" ? Foo1.childContextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo1.contextTypes = {
+  bar1: PropTypes.string
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
+  bar1: PropTypes.string
+} : void 0;
+export default class Foo2 extends React.Component {
+
+  render() {}
+}
+process.env.NODE_ENV !== "production" ? Foo2.childContextTypes = {
+  bar2: PropTypes.string
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo2.contextTypes = {
+  bar2: PropTypes.string
+} : void 0;
+process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
+  bar2: PropTypes.string
+} : void 0;

--- a/test/fixtures/es-class-static-property/expected-wrap-es5.js
+++ b/test/fixtures/es-class-static-property/expected-wrap-es5.js
@@ -29,6 +29,12 @@ var Foo1 = function (_React$Component) {
   return Foo1;
 }(React.Component);
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
 process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
   bar1: PropTypes.string
 } : void 0;
@@ -50,6 +56,12 @@ var Foo2 = function (_React$Component2) {
   return Foo2;
 }(React.Component);
 
+Foo2.contextTypes = {
+  bar2: PropTypes.string
+};
+Foo2.childContextTypes = {
+  bar2: PropTypes.string
+};
 exports.default = Foo2;
 process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   bar2: PropTypes.string

--- a/test/fixtures/es-class-static-property/expected-wrap-es6.js
+++ b/test/fixtures/es-class-static-property/expected-wrap-es6.js
@@ -3,6 +3,12 @@ class Foo1 extends React.Component {
   render() {}
 }
 
+Foo1.contextTypes = {
+  bar1: PropTypes.string
+};
+Foo1.childContextTypes = {
+  bar1: PropTypes.string
+};
 process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
   bar1: PropTypes.string
 } : void 0;
@@ -10,6 +16,12 @@ export default class Foo2 extends React.Component {
 
   render() {}
 }
+Foo2.contextTypes = {
+  bar2: PropTypes.string
+};
+Foo2.childContextTypes = {
+  bar2: PropTypes.string
+};
 process.env.NODE_ENV !== "production" ? Foo2.propTypes = {
   bar2: PropTypes.string
 } : void 0;

--- a/test/fixtures/not-react-assign-property/actual.js
+++ b/test/fixtures/not-react-assign-property/actual.js
@@ -2,3 +2,11 @@ var foo = {};
 foo.propTypes = {
   foo: PropTypes.string,
 };
+
+foo.contextTypes = {
+  foo: PropTypes.string,
+};
+
+foo.childContextTypes = {
+  foo: PropTypes.string,
+};

--- a/test/fixtures/not-react-assign-property/expected-remove-context-remove-es6.js
+++ b/test/fixtures/not-react-assign-property/expected-remove-context-remove-es6.js
@@ -1,0 +1,12 @@
+var foo = {};
+foo.propTypes = {
+  foo: PropTypes.string
+};
+
+foo.contextTypes = {
+  foo: PropTypes.string
+};
+
+foo.childContextTypes = {
+  foo: PropTypes.string
+};

--- a/test/fixtures/not-react-assign-property/expected-remove-context-wrap-es6.js
+++ b/test/fixtures/not-react-assign-property/expected-remove-context-wrap-es6.js
@@ -1,0 +1,12 @@
+var foo = {};
+foo.propTypes = {
+  foo: PropTypes.string
+};
+
+foo.contextTypes = {
+  foo: PropTypes.string
+};
+
+foo.childContextTypes = {
+  foo: PropTypes.string
+};

--- a/test/fixtures/not-react-assign-property/expected-remove-es6.js
+++ b/test/fixtures/not-react-assign-property/expected-remove-es6.js
@@ -2,3 +2,11 @@ var foo = {};
 foo.propTypes = {
   foo: PropTypes.string
 };
+
+foo.contextTypes = {
+  foo: PropTypes.string
+};
+
+foo.childContextTypes = {
+  foo: PropTypes.string
+};

--- a/test/fixtures/not-react-assign-property/expected-wrap-context-remove-es6.js
+++ b/test/fixtures/not-react-assign-property/expected-wrap-context-remove-es6.js
@@ -1,0 +1,12 @@
+var foo = {};
+foo.propTypes = {
+  foo: PropTypes.string
+};
+
+foo.contextTypes = {
+  foo: PropTypes.string
+};
+
+foo.childContextTypes = {
+  foo: PropTypes.string
+};

--- a/test/fixtures/not-react-assign-property/expected-wrap-context-wrap-es6.js
+++ b/test/fixtures/not-react-assign-property/expected-wrap-context-wrap-es6.js
@@ -1,0 +1,12 @@
+var foo = {};
+foo.propTypes = {
+  foo: PropTypes.string
+};
+
+foo.contextTypes = {
+  foo: PropTypes.string
+};
+
+foo.childContextTypes = {
+  foo: PropTypes.string
+};

--- a/test/fixtures/not-react-assign-property/expected-wrap-es6.js
+++ b/test/fixtures/not-react-assign-property/expected-wrap-es6.js
@@ -2,3 +2,11 @@ var foo = {};
 foo.propTypes = {
   foo: PropTypes.string
 };
+
+foo.contextTypes = {
+  foo: PropTypes.string
+};
+
+foo.childContextTypes = {
+  foo: PropTypes.string
+};

--- a/test/fixtures/not-react/actual.js
+++ b/test/fixtures/not-react/actual.js
@@ -2,4 +2,10 @@ var foo = {
   propTypes: {
     foo: 'bar',
   },
+  contextTypes: {
+    foo: 'bar',
+  },
+  childContextTypes: {
+    foo: 'bar',
+  },
 };

--- a/test/fixtures/not-react/expected-remove-context-remove-es6.js
+++ b/test/fixtures/not-react/expected-remove-context-remove-es6.js
@@ -1,0 +1,11 @@
+var foo = {
+  propTypes: {
+    foo: 'bar'
+  },
+  contextTypes: {
+    foo: 'bar'
+  },
+  childContextTypes: {
+    foo: 'bar'
+  }
+};

--- a/test/fixtures/not-react/expected-remove-context-wrap-es6.js
+++ b/test/fixtures/not-react/expected-remove-context-wrap-es6.js
@@ -1,0 +1,11 @@
+var foo = {
+  propTypes: {
+    foo: 'bar'
+  },
+  contextTypes: {
+    foo: 'bar'
+  },
+  childContextTypes: {
+    foo: 'bar'
+  }
+};

--- a/test/fixtures/not-react/expected-remove-es6.js
+++ b/test/fixtures/not-react/expected-remove-es6.js
@@ -1,5 +1,11 @@
 var foo = {
   propTypes: {
     foo: 'bar'
+  },
+  contextTypes: {
+    foo: 'bar'
+  },
+  childContextTypes: {
+    foo: 'bar'
   }
 };

--- a/test/fixtures/stateless-arrow-return-function/actual.js
+++ b/test/fixtures/stateless-arrow-return-function/actual.js
@@ -11,4 +11,14 @@ Message.propTypes = {
   mapList: PropTypes.array.isRequired,
 };
 
+
+Message.contextTypes = {
+  mapList: PropTypes.array.isRequired,
+};
+
+
+Message.childContextTypes = {
+  mapList: PropTypes.array.isRequired,
+};
+
 export default Message;

--- a/test/fixtures/stateless-arrow-return-function/expected-remove-context-remove-es6.js
+++ b/test/fixtures/stateless-arrow-return-function/expected-remove-context-remove-es6.js
@@ -1,0 +1,10 @@
+import React, { PropTypes } from 'react';
+import map from 'lodash/map';
+
+var Message = ({ mapList }) => {
+  return map(mapList, index => {
+    return <div />;
+  });
+};
+
+export default Message;

--- a/test/fixtures/stateless-arrow-return-function/expected-remove-context-wrap-es6.js
+++ b/test/fixtures/stateless-arrow-return-function/expected-remove-context-wrap-es6.js
@@ -1,0 +1,18 @@
+import React, { PropTypes } from 'react';
+import map from 'lodash/map';
+
+var Message = ({ mapList }) => {
+  return map(mapList, index => {
+    return <div />;
+  });
+};
+
+process.env.NODE_ENV !== "production" ? Message.contextTypes = {
+  mapList: PropTypes.array.isRequired
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Message.childContextTypes = {
+  mapList: PropTypes.array.isRequired
+} : void 0;
+
+export default Message;

--- a/test/fixtures/stateless-arrow-return-function/expected-remove-es5.js
+++ b/test/fixtures/stateless-arrow-return-function/expected-remove-es5.js
@@ -22,4 +22,12 @@ var Message = function Message(_ref) {
   });
 };
 
+Message.contextTypes = {
+  mapList: _react.PropTypes.array.isRequired
+};
+
+Message.childContextTypes = {
+  mapList: _react.PropTypes.array.isRequired
+};
+
 exports.default = Message;

--- a/test/fixtures/stateless-arrow-return-function/expected-remove-es6.js
+++ b/test/fixtures/stateless-arrow-return-function/expected-remove-es6.js
@@ -7,4 +7,12 @@ var Message = ({ mapList }) => {
   });
 };
 
+Message.contextTypes = {
+  mapList: PropTypes.array.isRequired
+};
+
+Message.childContextTypes = {
+  mapList: PropTypes.array.isRequired
+};
+
 export default Message;

--- a/test/fixtures/stateless-arrow-return-function/expected-wrap-context-remove-es6.js
+++ b/test/fixtures/stateless-arrow-return-function/expected-wrap-context-remove-es6.js
@@ -1,0 +1,14 @@
+import React, { PropTypes } from 'react';
+import map from 'lodash/map';
+
+var Message = ({ mapList }) => {
+  return map(mapList, index => {
+    return <div />;
+  });
+};
+
+process.env.NODE_ENV !== "production" ? Message.propTypes = {
+  mapList: PropTypes.array.isRequired
+} : void 0;
+
+export default Message;

--- a/test/fixtures/stateless-arrow-return-function/expected-wrap-context-wrap-es6.js
+++ b/test/fixtures/stateless-arrow-return-function/expected-wrap-context-wrap-es6.js
@@ -1,0 +1,22 @@
+import React, { PropTypes } from 'react';
+import map from 'lodash/map';
+
+var Message = ({ mapList }) => {
+  return map(mapList, index => {
+    return <div />;
+  });
+};
+
+process.env.NODE_ENV !== "production" ? Message.propTypes = {
+  mapList: PropTypes.array.isRequired
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Message.contextTypes = {
+  mapList: PropTypes.array.isRequired
+} : void 0;
+
+process.env.NODE_ENV !== "production" ? Message.childContextTypes = {
+  mapList: PropTypes.array.isRequired
+} : void 0;
+
+export default Message;

--- a/test/fixtures/stateless-arrow-return-function/expected-wrap-es5.js
+++ b/test/fixtures/stateless-arrow-return-function/expected-wrap-es5.js
@@ -26,4 +26,12 @@ process.env.NODE_ENV !== "production" ? Message.propTypes = {
   mapList: _react.PropTypes.array.isRequired
 } : void 0;
 
+Message.contextTypes = {
+  mapList: _react.PropTypes.array.isRequired
+};
+
+Message.childContextTypes = {
+  mapList: _react.PropTypes.array.isRequired
+};
+
 exports.default = Message;

--- a/test/fixtures/stateless-arrow-return-function/expected-wrap-es6.js
+++ b/test/fixtures/stateless-arrow-return-function/expected-wrap-es6.js
@@ -11,4 +11,12 @@ process.env.NODE_ENV !== "production" ? Message.propTypes = {
   mapList: PropTypes.array.isRequired
 } : void 0;
 
+Message.contextTypes = {
+  mapList: PropTypes.array.isRequired
+};
+
+Message.childContextTypes = {
+  mapList: PropTypes.array.isRequired
+};
+
 export default Message;


### PR DESCRIPTION
This PR introduce the opt-in option `contextMode` to set up how to deal with `contextTypes` and `childContextTypes`, same as the `mode` option it can take `remove` or `wrap` but do nothing by default.

I think this would help library authors using the `context` API deal with the  [#PropTypepocalypse](https://twitter.com/timdorr/status/852219173359034375) and remove the `prop-types` dependency from production build :smile:.

I think I made too many tests, but I will let you be the judge of that.

Tell me if there is anything I overlooked :v:.

Closes #77. 