### PR TITLE
Allow multiple libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,22 @@ For instance, you can ignore all the npm modules:
 ignoreFilenames: ['node_modules'],
 ```
 
+### `additionalLibraries`
+
+This option gives the possibility to remove other `propTypes` in addition to the canonical `prop-types`.
+
+For instance, by default
+```js
+import PropTypes from 'prop-types'
+import ImmutablePropTypes from 'react-immutable-proptypes'
+```
+will result in `propTypes` not to be removed; with:
+```js
+additionalLibraries: ['react-immutable-proptypes'],
+```
+both will be removed.
+
+
 ## Is it safe?
 
 If you are using the `propTypes` in a conventionnal way,

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ For instance, by default
 import PropTypes from 'prop-types'
 import ImmutablePropTypes from 'react-immutable-proptypes'
 ```
-will result in `propTypes` not to be removed; with:
+will result in the latter not to be removed, while with:
 ```js
 additionalLibraries: ['react-immutable-proptypes'],
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,7 @@ export default function ({ template, types }) {
           ignoreFilenames,
           types,
           removeImport: state.opts.removeImport || false,
+          libraries: (state.opts.additionalLibraries || []).concat('prop-types'),
         };
 
         // On program start, do an explicit traversal up front for this plugin.
@@ -155,7 +156,7 @@ export default function ({ template, types }) {
             programPath.traverse({
               ImportDeclaration(path) {
                 const { source, specifiers } = path.node;
-                if (source.value !== 'prop-types') {
+                if (!globalOptions.libraries.includes(source.value)) {
                   return;
                 }
                 const haveUsedSpecifiers = specifiers.some((specifier) => {
@@ -167,7 +168,6 @@ export default function ({ template, types }) {
                 if (!haveUsedSpecifiers) {
                   path.remove();
                 }
-                path.stop();
               },
             });
           } else {

--- a/test/fixtures/additional-libraries/actual.js
+++ b/test/fixtures/additional-libraries/actual.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import ImmutablePropTypes from 'react-immutable-proptypes'
+
+export default class Greeting extends Component {
+  constructor (props, context) {
+    super(props, context)
+    const appName = context.store.getState().appName
+    this.state = {
+      appName: appName
+    }
+  }
+
+  render () {
+    return <h1>Welcome {this.props.name} and {this.props.friends.join(', ')} to {this.state.appName}</h1>;
+  }
+}
+
+Greeting.propTypes = {
+  name: PropTypes.string.isRequired,
+  friends: ImmutablePropTypes.list.isRequired,
+}

--- a/test/fixtures/additional-libraries/expected-remove-es5.js
+++ b/test/fixtures/additional-libraries/expected-remove-es5.js
@@ -1,0 +1,55 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Greeting = function (_Component) {
+  _inherits(Greeting, _Component);
+
+  function Greeting(props, context) {
+    _classCallCheck(this, Greeting);
+
+    var _this = _possibleConstructorReturn(this, (Greeting.__proto__ || Object.getPrototypeOf(Greeting)).call(this, props, context));
+
+    var appName = context.store.getState().appName;
+    _this.state = {
+      appName: appName
+    };
+    return _this;
+  }
+
+  _createClass(Greeting, [{
+    key: 'render',
+    value: function render() {
+      return _react2.default.createElement(
+        'h1',
+        null,
+        'Welcome ',
+        this.props.name,
+        ' and ',
+        this.props.friends.join(', '),
+        ' to ',
+        this.state.appName
+      );
+    }
+  }]);
+
+  return Greeting;
+}(_react.Component);
+
+exports.default = Greeting;

--- a/test/fixtures/additional-libraries/expected-remove-es6.js
+++ b/test/fixtures/additional-libraries/expected-remove-es6.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+
+
+export default class Greeting extends Component {
+  constructor(props, context) {
+    super(props, context);
+    const appName = context.store.getState().appName;
+    this.state = {
+      appName: appName
+    };
+  }
+
+  render() {
+    return <h1>Welcome {this.props.name} and {this.props.friends.join(', ')} to {this.state.appName}</h1>;
+  }
+}

--- a/test/fixtures/additional-libraries/options.json
+++ b/test/fixtures/additional-libraries/options.json
@@ -1,0 +1,4 @@
+{
+  "additionalLibraries": ["react-immutable-proptypes"],
+  "removeImport": true
+}


### PR DESCRIPTION
I have a problem where I use other `PropTypes` libraries (e.g. [react-immutable-proptypes](https://www.npmjs.com/package/react-immutable-proptypes), [airbnb-prop-types](https://www.npmjs.com/package/airbnb-prop-types)), but those are not removed, and `prop-types` neither.

This PR gives an option to explicitly specify which additional libraries to remove/wrap.