### PR TITLE
fix(flow): use case

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,15 @@
   "bugs": {
     "url": "https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "babel-traverse": "^6.24.1"
+  },
   "devDependencies": {
     "babel-cli": "^6.22.2",
     "babel-core": "^6.22.1",
     "babel-eslint": "^7.1.1",
+    "babel-plugin-flow-react-proptypes": "^2.1.3",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",
     "babel-preset-stage-0": "^6.22.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 // @flow weak
+/* eslint-disable global-require, import/no-dynamic-require */
 
+import { visitors } from 'babel-traverse';
 import isAnnotatedForRemoval from './isAnnotatedForRemoval';
 import isStatelessComponent from './isStatelessComponent';
 import remove from './remove';
@@ -73,6 +75,15 @@ export default function ({ template, types }) {
           removeImport: state.opts.removeImport || false,
           libraries: (state.opts.additionalLibraries || []).concat('prop-types'),
         };
+
+        if (state.opts.plugins) {
+          const pluginsVisitors = state.opts.plugins.map((pluginName) => {
+            const plugin = require(pluginName);
+            return plugin({ template, types }).visitor;
+          });
+
+          programPath.traverse(visitors.merge(pluginsVisitors));
+        }
 
         // On program start, do an explicit traversal up front for this plugin.
         programPath.traverse({

--- a/test/fixtures/flow/actual.js
+++ b/test/fixtures/flow/actual.js
@@ -1,0 +1,23 @@
+class Foo1 extends Component {
+  props:  {
+    bar1?: string,
+  };
+  render() {}
+}
+
+type Props2 = {
+  bar2?: string
+}
+
+class Foo2 extends Component {
+  props: Props2;
+  render() {}
+}
+
+type Props3 = {
+  bar3?: string,
+}
+
+function Foo3(props: Props3) {
+  return <div />;
+}

--- a/test/fixtures/flow/expected-wrap-es5.js
+++ b/test/fixtures/flow/expected-wrap-es5.js
@@ -1,0 +1,59 @@
+"use strict";
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Foo1 = function (_Component) {
+  _inherits(Foo1, _Component);
+
+  function Foo1() {
+    _classCallCheck(this, Foo1);
+
+    return _possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
+  }
+
+  _createClass(Foo1, [{
+    key: "render",
+    value: function render() {}
+  }]);
+
+  return Foo1;
+}(Component);
+
+Foo1.propTypes = process.env.NODE_ENV !== "production" ? {
+  bar1: require("prop-types").string
+} : {};
+
+var Foo2 = function (_Component2) {
+  _inherits(Foo2, _Component2);
+
+  function Foo2() {
+    _classCallCheck(this, Foo2);
+
+    return _possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
+  }
+
+  _createClass(Foo2, [{
+    key: "render",
+    value: function render() {}
+  }]);
+
+  return Foo2;
+}(Component);
+
+Foo2.propTypes = process.env.NODE_ENV !== "production" ? {
+  bar2: require("prop-types").string
+} : {};
+
+
+function Foo3(props) {
+  return React.createElement("div", null);
+}
+Foo3.propTypes = process.env.NODE_ENV !== "production" ? {
+  bar3: require("prop-types").string
+} : {};

--- a/test/fixtures/flow/options.json
+++ b/test/fixtures/flow/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "babel-plugin-flow-react-proptypes",
+    "babel-plugin-transform-flow-strip-types"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,7 +163,7 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.22.1, babel-core@^6.24.1:
+babel-core@^6.18.0, babel-core@^6.22.1, babel-core@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.24.1.tgz#8c428564dce1e1f41fb337ec34f4c3b022b5ad83"
   dependencies:
@@ -346,6 +346,15 @@ babel-plugin-check-es2015-constants@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-flow-react-proptypes@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-flow-react-proptypes/-/babel-plugin-flow-react-proptypes-2.1.3.tgz#6db20e985baadf409ef3698b7f4645bb96761250"
+  dependencies:
+    babel-core "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -806,7 +815,7 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.24.1:
+babel-template@^6.16.0, babel-template@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:
@@ -816,7 +825,7 @@ babel-template@^6.24.1:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.23.1, babel-traverse@^6.24.1:
+babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -830,7 +839,7 @@ babel-traverse@^6.23.1, babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:


### PR DESCRIPTION
I couldn't find a better solution. The plugin resolution order is critical here. We need to be before the classes to be transpiled but after the propTypes to be generated. That's the simpler fix I could think of.

Fix #104.