### PR TITLE
Use Array.prototype.indexOf for Node 4 support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,7 @@ export default function ({ template, types }) {
             programPath.traverse({
               ImportDeclaration(path) {
                 const { source, specifiers } = path.node;
-                if (!globalOptions.libraries.includes(source.value)) {
+                if (globalOptions.libraries.indexOf(source.value) === -1) {
                   return;
                 }
                 const haveUsedSpecifiers = specifiers.some((specifier) => {


### PR DESCRIPTION
Fixes "globalOptions.libraries.includes is not a function" error running in Node 4