### PR TITLE
fix(babel): Support latest beta version of babel 7

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,14 +67,14 @@ export default function({ template, types, traverse }) {
               if (process.env.NODE_ENV !== "production") {
                 NODE;
               }
-            `, 
+            `,
             { placeholderWhitelist: new Set(['NODE']) }
           ),
           wrapTemplate: template(
             `
               LEFT = process.env.NODE_ENV !== "production" ? RIGHT : {}
-            `, 
-             { placeholderWhitelist: new Set(['LEFT', 'RIGHT']) }
+            `,
+            { placeholderWhitelist: new Set(['LEFT', 'RIGHT']) }
           ),
           mode: state.opts.mode || 'remove',
           ignoreFilenames,

--- a/src/index.js
+++ b/src/index.js
@@ -62,14 +62,20 @@ export default function({ template, types, traverse }) {
 
         const globalOptions = {
           visitedKey: `transform-react-remove-prop-types${Date.now()}`,
-          unsafeWrapTemplate: template(`
-            if (process.env.NODE_ENV !== "production") {
-              NODE;
-            }
-          `, { placeholderWhitelist: new Set(['NODE']) }),
-          wrapTemplate: template(`
-            LEFT = process.env.NODE_ENV !== "production" ? RIGHT : {}
-          `, { placeholderWhitelist: new Set(['LEFT', 'RIGHT']) }),
+          unsafeWrapTemplate: template(
+            `
+              if (process.env.NODE_ENV !== "production") {
+                NODE;
+              }
+            `, 
+            { placeholderWhitelist: new Set(['NODE']) }
+          ),
+          wrapTemplate: template(
+            `
+              LEFT = process.env.NODE_ENV !== "production" ? RIGHT : {}
+            `, 
+             { placeholderWhitelist: new Set(['LEFT', 'RIGHT']) }
+          ),
           mode: state.opts.mode || 'remove',
           ignoreFilenames,
           types,

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export default function({ template, types, traverse }) {
           `, { placeholderWhitelist: new Set(['NODE']) }),
           wrapTemplate: template(`
             LEFT = process.env.NODE_ENV !== "production" ? RIGHT : {}
-          `, { placeholderWhitelist: new Set(['LEFT', 'RIGHT']) })),
+          `, { placeholderWhitelist: new Set(['LEFT', 'RIGHT']) }),
           mode: state.opts.mode || 'remove',
           ignoreFilenames,
           types,

--- a/src/index.js
+++ b/src/index.js
@@ -66,10 +66,10 @@ export default function({ template, types, traverse }) {
             if (process.env.NODE_ENV !== "production") {
               NODE;
             }
-          `),
+          `, { placeholderWhitelist: new Set(['NODE']) }),
           wrapTemplate: template(`
             LEFT = process.env.NODE_ENV !== "production" ? RIGHT : {}
-          `),
+          `, { placeholderWhitelist: new Set(['LEFT', 'RIGHT']) })),
           mode: state.opts.mode || 'remove',
           ignoreFilenames,
           types,


### PR DESCRIPTION
This adds the `placeholderWhitelist` option to the created templates.
This will be ignored in older babel versions. This is also the reason I did not update babel to the latest beta, because I wanted to see if this change still works on versions before the template change happened (<beta4).

Fixes #130