### PR TITLE
Fix babel 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@babel/cli": "^7.0.0-beta.35",
     "@babel/core": "^7.0.0-beta.35",
     "@babel/generator": "^7.0.0-beta.35",
+    "@babel/plugin-external-helpers": "^7.0.0-beta.35",
+    "@babel/plugin-proposal-class-properties": "^7.0.0-beta.35",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0-beta.35",
     "@babel/preset-env": "^7.0.0-beta.35",
     "@babel/preset-flow": "^7.0.0-beta.35",

--- a/src/index.js
+++ b/src/index.js
@@ -96,8 +96,6 @@ export default function({ template, types, traverse }) {
             }
 
             let plugin = require(pluginName)
-
-            // Required for `babel-plugin-transform-flow-strip-types`
             if (typeof plugin !== 'function') {
               plugin = plugin.default
             }

--- a/src/index.js
+++ b/src/index.js
@@ -68,13 +68,13 @@ export default function({ template, types, traverse }) {
                 NODE;
               }
             `,
-            { placeholderWhitelist: new Set(['NODE']) }
+            { placeholderPattern: /^NODE$/ }
           ),
           wrapTemplate: template(
             `
               LEFT = process.env.NODE_ENV !== "production" ? RIGHT : {}
             `,
-            { placeholderWhitelist: new Set(['LEFT', 'RIGHT']) }
+            { placeholderPattern: /^(LEFT|RIGHT)$/ }
           ),
           mode: state.opts.mode || 'remove',
           ignoreFilenames,

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -7,7 +7,8 @@ import { assert } from 'chai'
 import pathExists from 'path-exists'
 import { transformFileSync } from '@babel/core'
 import babelPluginSyntaxJsx from '@babel/plugin-syntax-jsx'
-// import babelPluginTransformClassProperties from 'babel-plugin-transform-class-properties'
+import babelPluginExternalHelpers from '@babel/plugin-external-helpers'
+import babelPluginTransformClassProperties from '@babel/plugin-proposal-class-properties'
 import babelPluginTransformReactRemovePropTypes from '../src/index'
 import { trim } from './utils'
 
@@ -53,6 +54,7 @@ describe('fixtures', () => {
             case 'remove-es5':
               babelConfig = {
                 plugins: [
+                  babelPluginExternalHelpers,
                   [
                     babelPluginTransformReactRemovePropTypes,
                     {
@@ -67,6 +69,7 @@ describe('fixtures', () => {
             case 'wrap-es5':
               babelConfig = {
                 plugins: [
+                  babelPluginExternalHelpers,
                   [
                     babelPluginTransformReactRemovePropTypes,
                     {
@@ -82,8 +85,9 @@ describe('fixtures', () => {
               babelConfig = {
                 babelrc: false,
                 plugins: [
+                  babelPluginExternalHelpers,
                   babelPluginSyntaxJsx,
-                  // babelPluginTransformClassProperties,
+                  babelPluginTransformClassProperties,
                   [
                     babelPluginTransformReactRemovePropTypes,
                     {
@@ -99,8 +103,9 @@ describe('fixtures', () => {
               babelConfig = {
                 babelrc: false,
                 plugins: [
+                  babelPluginExternalHelpers,
                   babelPluginSyntaxJsx,
-                  // babelPluginTransformClassProperties,
+                  babelPluginTransformClassProperties,
                   [
                     babelPluginTransformReactRemovePropTypes,
                     {
@@ -114,7 +119,10 @@ describe('fixtures', () => {
 
             default:
               babelConfig = {
-                plugins: [[babelPluginTransformReactRemovePropTypes, options]],
+                plugins: [
+                  babelPluginExternalHelpers,
+                  [babelPluginTransformReactRemovePropTypes, options],
+                ],
               }
           }
 

--- a/test/fixtures/additional-libraries/expected-remove-es5.js
+++ b/test/fixtures/additional-libraries/expected-remove-es5.js
@@ -5,33 +5,18 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _react = _interopRequireWildcard(require("react"));
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
-
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+var _react = babelHelpers.interopRequireWildcard(require("react"));
 
 var Greeting =
 /*#__PURE__*/
 function (_Component) {
-  _inherits(Greeting, _Component);
+  babelHelpers.inherits(Greeting, _Component);
 
   function Greeting(props, context) {
     var _this;
 
-    _classCallCheck(this, Greeting);
-
-    _this = _possibleConstructorReturn(this, (Greeting.__proto__ || Object.getPrototypeOf(Greeting)).call(this, props, context));
+    babelHelpers.classCallCheck(this, Greeting);
+    _this = babelHelpers.possibleConstructorReturn(this, (Greeting.__proto__ || Object.getPrototypeOf(Greeting)).call(this, props, context));
     var appName = context.store.getState().appName;
     _this.state = {
       appName: appName
@@ -39,13 +24,12 @@ function (_Component) {
     return _this;
   }
 
-  _createClass(Greeting, [{
+  babelHelpers.createClass(Greeting, [{
     key: "render",
     value: function render() {
       return _react.default.createElement("h1", null, "Welcome ", this.props.name, " and ", this.props.friends.join(', '), " to ", this.state.appName);
     }
   }]);
-
   return Greeting;
 }(_react.Component);
 

--- a/test/fixtures/class-comment-annotation/expected-remove-es5.js
+++ b/test/fixtures/class-comment-annotation/expected-remove-es5.js
@@ -5,42 +5,26 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _react = _interopRequireDefault(require("react"));
+var _react = babelHelpers.interopRequireDefault(require("react"));
 
-var _propTypes = _interopRequireDefault(require("prop-types"));
+var _propTypes = babelHelpers.interopRequireDefault(require("prop-types"));
 
-var _Parent = _interopRequireDefault(require("./Parent"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+var _Parent = babelHelpers.interopRequireDefault(require("./Parent"));
 
 var Foo =
 /*#__PURE__*/
 function (_ParentComponent) {
-  _inherits(Foo, _ParentComponent);
+  babelHelpers.inherits(Foo, _ParentComponent);
 
   function Foo() {
-    _classCallCheck(this, Foo);
-
-    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo);
+    return babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
   }
 
-  _createClass(Foo, [{
+  babelHelpers.createClass(Foo, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo;
 }(_Parent.default);
 

--- a/test/fixtures/dont-remove-used-import/expected-remove-es5.js
+++ b/test/fixtures/dont-remove-used-import/expected-remove-es5.js
@@ -5,37 +5,20 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _react = _interopRequireWildcard(require("react"));
+var _react = babelHelpers.interopRequireWildcard(require("react"));
 
-var _propTypes = _interopRequireDefault(require("prop-types"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
-
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+var _propTypes = babelHelpers.interopRequireDefault(require("prop-types"));
 
 var Greeting =
 /*#__PURE__*/
 function (_Component) {
-  _inherits(Greeting, _Component);
+  babelHelpers.inherits(Greeting, _Component);
 
   function Greeting(props, context) {
     var _this;
 
-    _classCallCheck(this, Greeting);
-
-    _this = _possibleConstructorReturn(this, (Greeting.__proto__ || Object.getPrototypeOf(Greeting)).call(this, props, context));
+    babelHelpers.classCallCheck(this, Greeting);
+    _this = babelHelpers.possibleConstructorReturn(this, (Greeting.__proto__ || Object.getPrototypeOf(Greeting)).call(this, props, context));
     var appName = context.store.getState().appName;
     _this.state = {
       appName: appName
@@ -43,13 +26,12 @@ function (_Component) {
     return _this;
   }
 
-  _createClass(Greeting, [{
+  babelHelpers.createClass(Greeting, [{
     key: "render",
     value: function render() {
       return _react.default.createElement("h1", null, "Welcome ", this.props.name, " to ", this.state.appName);
     }
   }]);
-
   return Greeting;
 }(_react.Component);
 

--- a/test/fixtures/es-class-assign-property-variable-export/expected-remove-es5.js
+++ b/test/fixtures/es-class-assign-property-variable-export/expected-remove-es5.js
@@ -4,19 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.propTypes = void 0;
-
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var propTypes = {
   foo: PropTypes.string
 };
@@ -25,18 +12,16 @@ exports.propTypes = propTypes;
 var Foo =
 /*#__PURE__*/
 function (_React$Component) {
-  _inherits(Foo, _React$Component);
+  babelHelpers.inherits(Foo, _React$Component);
 
   function Foo() {
-    _classCallCheck(this, Foo);
-
-    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo);
+    return babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
   }
 
-  _createClass(Foo, [{
+  babelHelpers.createClass(Foo, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo;
 }(React.Component);

--- a/test/fixtures/es-class-assign-property-variable-export/expected-wrap-es5.js
+++ b/test/fixtures/es-class-assign-property-variable-export/expected-wrap-es5.js
@@ -4,19 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.propTypes = void 0;
-
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var propTypes = {
   foo: PropTypes.string
 };
@@ -25,19 +12,17 @@ exports.propTypes = propTypes;
 var Foo =
 /*#__PURE__*/
 function (_React$Component) {
-  _inherits(Foo, _React$Component);
+  babelHelpers.inherits(Foo, _React$Component);
 
   function Foo() {
-    _classCallCheck(this, Foo);
-
-    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo);
+    return babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
   }
 
-  _createClass(Foo, [{
+  babelHelpers.createClass(Foo, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo;
 }(React.Component);
 

--- a/test/fixtures/es-class-assign-property-variable/expected-remove-es5.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-remove-es5.js
@@ -1,15 +1,3 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var propTypes = {
   foo: PropTypes.string
 };
@@ -17,18 +5,16 @@ var propTypes = {
 var Foo =
 /*#__PURE__*/
 function (_React$Component) {
-  _inherits(Foo, _React$Component);
+  babelHelpers.inherits(Foo, _React$Component);
 
   function Foo() {
-    _classCallCheck(this, Foo);
-
-    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo);
+    return babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
   }
 
-  _createClass(Foo, [{
+  babelHelpers.createClass(Foo, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo;
 }(React.Component);

--- a/test/fixtures/es-class-assign-property-variable/expected-wrap-es5.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-wrap-es5.js
@@ -1,15 +1,3 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var propTypes = {
   foo: PropTypes.string
 };
@@ -17,19 +5,17 @@ var propTypes = {
 var Foo =
 /*#__PURE__*/
 function (_React$Component) {
-  _inherits(Foo, _React$Component);
+  babelHelpers.inherits(Foo, _React$Component);
 
   function Foo() {
-    _classCallCheck(this, Foo);
-
-    return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo);
+    return babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
   }
 
-  _createClass(Foo, [{
+  babelHelpers.createClass(Foo, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo;
 }(React.Component);
 

--- a/test/fixtures/es-class-assign-property/expected-remove-es5.js
+++ b/test/fixtures/es-class-assign-property/expected-remove-es5.js
@@ -1,49 +1,33 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var Foo1 =
 /*#__PURE__*/
 function (_React$Component) {
-  _inherits(Foo1, _React$Component);
+  babelHelpers.inherits(Foo1, _React$Component);
 
   function Foo1() {
-    _classCallCheck(this, Foo1);
-
-    return _possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo1);
+    return babelHelpers.possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
   }
 
-  _createClass(Foo1, [{
+  babelHelpers.createClass(Foo1, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo1;
 }(React.Component);
 
 var Foo2 =
 /*#__PURE__*/
 function (_React$PureComponent) {
-  _inherits(Foo2, _React$PureComponent);
+  babelHelpers.inherits(Foo2, _React$PureComponent);
 
   function Foo2() {
-    _classCallCheck(this, Foo2);
-
-    return _possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo2);
+    return babelHelpers.possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
   }
 
-  _createClass(Foo2, [{
+  babelHelpers.createClass(Foo2, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo2;
 }(React.PureComponent);

--- a/test/fixtures/es-class-assign-property/expected-wrap-es5.js
+++ b/test/fixtures/es-class-assign-property/expected-wrap-es5.js
@@ -1,31 +1,17 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var Foo1 =
 /*#__PURE__*/
 function (_React$Component) {
-  _inherits(Foo1, _React$Component);
+  babelHelpers.inherits(Foo1, _React$Component);
 
   function Foo1() {
-    _classCallCheck(this, Foo1);
-
-    return _possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo1);
+    return babelHelpers.possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
   }
 
-  _createClass(Foo1, [{
+  babelHelpers.createClass(Foo1, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo1;
 }(React.Component);
 
@@ -36,19 +22,17 @@ Foo1.propTypes = process.env.NODE_ENV !== "production" ? {
 var Foo2 =
 /*#__PURE__*/
 function (_React$PureComponent) {
-  _inherits(Foo2, _React$PureComponent);
+  babelHelpers.inherits(Foo2, _React$PureComponent);
 
   function Foo2() {
-    _classCallCheck(this, Foo2);
-
-    return _possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo2);
+    return babelHelpers.possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
   }
 
-  _createClass(Foo2, [{
+  babelHelpers.createClass(Foo2, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo2;
 }(React.PureComponent);
 

--- a/test/fixtures/es-class-extend-component/expected-remove-es5.js
+++ b/test/fixtures/es-class-extend-component/expected-remove-es5.js
@@ -1,49 +1,33 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var Foo1 =
 /*#__PURE__*/
 function (_Component) {
-  _inherits(Foo1, _Component);
+  babelHelpers.inherits(Foo1, _Component);
 
   function Foo1() {
-    _classCallCheck(this, Foo1);
-
-    return _possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo1);
+    return babelHelpers.possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
   }
 
-  _createClass(Foo1, [{
+  babelHelpers.createClass(Foo1, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo1;
 }(Component);
 
 var Foo2 =
 /*#__PURE__*/
 function (_Component2) {
-  _inherits(Foo2, _Component2);
+  babelHelpers.inherits(Foo2, _Component2);
 
   function Foo2() {
-    _classCallCheck(this, Foo2);
-
-    return _possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo2);
+    return babelHelpers.possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
   }
 
-  _createClass(Foo2, [{
+  babelHelpers.createClass(Foo2, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo2;
 }(Component);

--- a/test/fixtures/es-class-extend-component/expected-wrap-es5.js
+++ b/test/fixtures/es-class-extend-component/expected-wrap-es5.js
@@ -1,31 +1,17 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var Foo1 =
 /*#__PURE__*/
 function (_Component) {
-  _inherits(Foo1, _Component);
+  babelHelpers.inherits(Foo1, _Component);
 
   function Foo1() {
-    _classCallCheck(this, Foo1);
-
-    return _possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo1);
+    return babelHelpers.possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
   }
 
-  _createClass(Foo1, [{
+  babelHelpers.createClass(Foo1, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo1;
 }(Component);
 
@@ -36,19 +22,17 @@ Foo1.propTypes = process.env.NODE_ENV !== "production" ? {
 var Foo2 =
 /*#__PURE__*/
 function (_Component2) {
-  _inherits(Foo2, _Component2);
+  babelHelpers.inherits(Foo2, _Component2);
 
   function Foo2() {
-    _classCallCheck(this, Foo2);
-
-    return _possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo2);
+    return babelHelpers.possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
   }
 
-  _createClass(Foo2, [{
+  babelHelpers.createClass(Foo2, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo2;
 }(Component);
 

--- a/test/fixtures/es-class-inheritance/expected-remove-es5.js
+++ b/test/fixtures/es-class-inheritance/expected-remove-es5.js
@@ -7,27 +7,14 @@ exports.Foo3 = void 0;
 
 var _class, _temp;
 
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var PureRenderComponent =
 /*#__PURE__*/
 function (_Component) {
-  _inherits(PureRenderComponent, _Component);
+  babelHelpers.inherits(PureRenderComponent, _Component);
 
   function PureRenderComponent() {
-    _classCallCheck(this, PureRenderComponent);
-
-    return _possibleConstructorReturn(this, (PureRenderComponent.__proto__ || Object.getPrototypeOf(PureRenderComponent)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, PureRenderComponent);
+    return babelHelpers.possibleConstructorReturn(this, (PureRenderComponent.__proto__ || Object.getPrototypeOf(PureRenderComponent)).apply(this, arguments));
   }
 
   return PureRenderComponent;
@@ -36,38 +23,34 @@ function (_Component) {
 var Foo1 =
 /*#__PURE__*/
 function (_PureRenderComponent) {
-  _inherits(Foo1, _PureRenderComponent);
+  babelHelpers.inherits(Foo1, _PureRenderComponent);
 
   function Foo1() {
-    _classCallCheck(this, Foo1);
-
-    return _possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo1);
+    return babelHelpers.possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
   }
 
-  _createClass(Foo1, [{
+  babelHelpers.createClass(Foo1, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo1;
 }(PureRenderComponent);
 
 var Foo2 =
 /*#__PURE__*/
 function (_PureRenderComponent2) {
-  _inherits(Foo2, _PureRenderComponent2);
+  babelHelpers.inherits(Foo2, _PureRenderComponent2);
 
   function Foo2() {
-    _classCallCheck(this, Foo2);
-
-    return _possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo2);
+    return babelHelpers.possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
   }
 
-  _createClass(Foo2, [{
+  babelHelpers.createClass(Foo2, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo2;
 }(PureRenderComponent);
 
@@ -76,14 +59,13 @@ var Foo3 = (_temp = _class =
 /*#__PURE__*/
 function () {
   function Foo3() {
-    _classCallCheck(this, Foo3);
+    babelHelpers.classCallCheck(this, Foo3);
   }
 
-  _createClass(Foo3, [{
+  babelHelpers.createClass(Foo3, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo3;
 }(), Object.defineProperty(_class, "propTypes", {
   configurable: true,

--- a/test/fixtures/es-class-inheritance/expected-wrap-es5.js
+++ b/test/fixtures/es-class-inheritance/expected-wrap-es5.js
@@ -7,27 +7,14 @@ exports.Foo3 = void 0;
 
 var _class, _temp;
 
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var PureRenderComponent =
 /*#__PURE__*/
 function (_Component) {
-  _inherits(PureRenderComponent, _Component);
+  babelHelpers.inherits(PureRenderComponent, _Component);
 
   function PureRenderComponent() {
-    _classCallCheck(this, PureRenderComponent);
-
-    return _possibleConstructorReturn(this, (PureRenderComponent.__proto__ || Object.getPrototypeOf(PureRenderComponent)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, PureRenderComponent);
+    return babelHelpers.possibleConstructorReturn(this, (PureRenderComponent.__proto__ || Object.getPrototypeOf(PureRenderComponent)).apply(this, arguments));
   }
 
   return PureRenderComponent;
@@ -36,19 +23,17 @@ function (_Component) {
 var Foo1 =
 /*#__PURE__*/
 function (_PureRenderComponent) {
-  _inherits(Foo1, _PureRenderComponent);
+  babelHelpers.inherits(Foo1, _PureRenderComponent);
 
   function Foo1() {
-    _classCallCheck(this, Foo1);
-
-    return _possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo1);
+    return babelHelpers.possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
   }
 
-  _createClass(Foo1, [{
+  babelHelpers.createClass(Foo1, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo1;
 }(PureRenderComponent);
 
@@ -59,19 +44,17 @@ Foo1.propTypes = process.env.NODE_ENV !== "production" ? {
 var Foo2 =
 /*#__PURE__*/
 function (_PureRenderComponent2) {
-  _inherits(Foo2, _PureRenderComponent2);
+  babelHelpers.inherits(Foo2, _PureRenderComponent2);
 
   function Foo2() {
-    _classCallCheck(this, Foo2);
-
-    return _possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo2);
+    return babelHelpers.possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
   }
 
-  _createClass(Foo2, [{
+  babelHelpers.createClass(Foo2, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo2;
 }(PureRenderComponent);
 
@@ -83,14 +66,13 @@ var Foo3 = (_temp = _class =
 /*#__PURE__*/
 function () {
   function Foo3() {
-    _classCallCheck(this, Foo3);
+    babelHelpers.classCallCheck(this, Foo3);
   }
 
-  _createClass(Foo3, [{
+  babelHelpers.createClass(Foo3, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo3;
 }(), Object.defineProperty(_class, "propTypes", {
   configurable: true,

--- a/test/fixtures/es-class-no-name/expected-remove-es5.js
+++ b/test/fixtures/es-class-no-name/expected-remove-es5.js
@@ -5,34 +5,20 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var _default =
 /*#__PURE__*/
 function (_React$Component) {
-  _inherits(_default, _React$Component);
+  babelHelpers.inherits(_default, _React$Component);
 
   function _default() {
-    _classCallCheck(this, _default);
-
-    return _possibleConstructorReturn(this, (_default.__proto__ || Object.getPrototypeOf(_default)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, _default);
+    return babelHelpers.possibleConstructorReturn(this, (_default.__proto__ || Object.getPrototypeOf(_default)).apply(this, arguments));
   }
 
-  _createClass(_default, [{
+  babelHelpers.createClass(_default, [{
     key: "render",
     value: function render() {}
   }]);
-
   return _default;
 }(React.Component);
 

--- a/test/fixtures/es-class-no-name/expected-wrap-es5.js
+++ b/test/fixtures/es-class-no-name/expected-wrap-es5.js
@@ -7,34 +7,20 @@ exports.default = void 0;
 
 var _class, _temp;
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var _default = (_temp = _class =
 /*#__PURE__*/
 function (_React$Component) {
-  _inherits(_default, _React$Component);
+  babelHelpers.inherits(_default, _React$Component);
 
   function _default() {
-    _classCallCheck(this, _default);
-
-    return _possibleConstructorReturn(this, (_default.__proto__ || Object.getPrototypeOf(_default)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, _default);
+    return babelHelpers.possibleConstructorReturn(this, (_default.__proto__ || Object.getPrototypeOf(_default)).apply(this, arguments));
   }
 
-  _createClass(_default, [{
+  babelHelpers.createClass(_default, [{
     key: "render",
     value: function render() {}
   }]);
-
   return _default;
 }(React.Component), Object.defineProperty(_class, "propTypes", {
   configurable: true,

--- a/test/fixtures/es-class-static-property/expected-remove-es5.js
+++ b/test/fixtures/es-class-static-property/expected-remove-es5.js
@@ -5,53 +5,37 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var Foo1 =
 /*#__PURE__*/
 function (_React$Component) {
-  _inherits(Foo1, _React$Component);
+  babelHelpers.inherits(Foo1, _React$Component);
 
   function Foo1() {
-    _classCallCheck(this, Foo1);
-
-    return _possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo1);
+    return babelHelpers.possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
   }
 
-  _createClass(Foo1, [{
+  babelHelpers.createClass(Foo1, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo1;
 }(React.Component);
 
 var Foo2 =
 /*#__PURE__*/
 function (_React$Component2) {
-  _inherits(Foo2, _React$Component2);
+  babelHelpers.inherits(Foo2, _React$Component2);
 
   function Foo2() {
-    _classCallCheck(this, Foo2);
-
-    return _possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo2);
+    return babelHelpers.possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
   }
 
-  _createClass(Foo2, [{
+  babelHelpers.createClass(Foo2, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo2;
 }(React.Component);
 

--- a/test/fixtures/es-class-static-property/expected-wrap-es5.js
+++ b/test/fixtures/es-class-static-property/expected-wrap-es5.js
@@ -5,34 +5,20 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var Foo1 =
 /*#__PURE__*/
 function (_React$Component) {
-  _inherits(Foo1, _React$Component);
+  babelHelpers.inherits(Foo1, _React$Component);
 
   function Foo1() {
-    _classCallCheck(this, Foo1);
-
-    return _possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo1);
+    return babelHelpers.possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
   }
 
-  _createClass(Foo1, [{
+  babelHelpers.createClass(Foo1, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo1;
 }(React.Component);
 
@@ -43,19 +29,17 @@ Foo1.propTypes = process.env.NODE_ENV !== "production" ? {
 var Foo2 =
 /*#__PURE__*/
 function (_React$Component2) {
-  _inherits(Foo2, _React$Component2);
+  babelHelpers.inherits(Foo2, _React$Component2);
 
   function Foo2() {
-    _classCallCheck(this, Foo2);
-
-    return _possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo2);
+    return babelHelpers.possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
   }
 
-  _createClass(Foo2, [{
+  babelHelpers.createClass(Foo2, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo2;
 }(React.Component);
 

--- a/test/fixtures/flow/expected-wrap-es5.js
+++ b/test/fixtures/flow/expected-wrap-es5.js
@@ -1,31 +1,17 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var Foo1 =
 /*#__PURE__*/
 function (_Component) {
-  _inherits(Foo1, _Component);
+  babelHelpers.inherits(Foo1, _Component);
 
   function Foo1() {
-    _classCallCheck(this, Foo1);
-
-    return _possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo1);
+    return babelHelpers.possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
   }
 
-  _createClass(Foo1, [{
+  babelHelpers.createClass(Foo1, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo1;
 }(Component);
 
@@ -39,19 +25,17 @@ var babelPluginFlowReactPropTypes_proptype_Props2 = {
 var Foo2 =
 /*#__PURE__*/
 function (_Component2) {
-  _inherits(Foo2, _Component2);
+  babelHelpers.inherits(Foo2, _Component2);
 
   function Foo2() {
-    _classCallCheck(this, Foo2);
-
-    return _possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo2);
+    return babelHelpers.possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
   }
 
-  _createClass(Foo2, [{
+  babelHelpers.createClass(Foo2, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo2;
 }(Component);
 

--- a/test/fixtures/flow/options.json
+++ b/test/fixtures/flow/options.json
@@ -3,6 +3,6 @@
     ["babel-plugin-flow-react-proptypes", {
       "omitRuntimeTypeExport": true
     }],
-    "babel-plugin-transform-flow-strip-types"
+    "@babel/plugin-transform-flow-strip-types"
   ]
 }

--- a/test/fixtures/remove-import-proptypes/expected-remove-es5.js
+++ b/test/fixtures/remove-import-proptypes/expected-remove-es5.js
@@ -1,38 +1,22 @@
 "use strict";
 
-var _react = _interopRequireWildcard(require("react"));
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
-
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+var _react = babelHelpers.interopRequireWildcard(require("react"));
 
 var Greeting =
 /*#__PURE__*/
 function (_Component) {
-  _inherits(Greeting, _Component);
+  babelHelpers.inherits(Greeting, _Component);
 
   function Greeting() {
-    _classCallCheck(this, Greeting);
-
-    return _possibleConstructorReturn(this, (Greeting.__proto__ || Object.getPrototypeOf(Greeting)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Greeting);
+    return babelHelpers.possibleConstructorReturn(this, (Greeting.__proto__ || Object.getPrototypeOf(Greeting)).apply(this, arguments));
   }
 
-  _createClass(Greeting, [{
+  babelHelpers.createClass(Greeting, [{
     key: "render",
     value: function render() {
       return _react.default.createElement("h1", null, "Hello, ", this.props.name);
     }
   }]);
-
   return Greeting;
 }(_react.Component);

--- a/test/fixtures/shared-prop-type-variable/expected-remove-es5.js
+++ b/test/fixtures/shared-prop-type-variable/expected-remove-es5.js
@@ -5,13 +5,11 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = Foo;
 
-var _react = _interopRequireDefault(require("react"));
+var _react = babelHelpers.interopRequireDefault(require("react"));
 
 var _underscore = require("underscore");
 
-var _bar = _interopRequireDefault(require("./bar"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+var _bar = babelHelpers.interopRequireDefault(require("./bar"));
 
 var PropTypes = _react.default.PropTypes;
 var propTypes = {

--- a/test/fixtures/shared-prop-type-variable/expected-wrap-es5.js
+++ b/test/fixtures/shared-prop-type-variable/expected-wrap-es5.js
@@ -5,13 +5,11 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = Foo;
 
-var _react = _interopRequireDefault(require("react"));
+var _react = babelHelpers.interopRequireDefault(require("react"));
 
 var _underscore = require("underscore");
 
-var _bar = _interopRequireDefault(require("./bar"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+var _bar = babelHelpers.interopRequireDefault(require("./bar"));
 
 var PropTypes = _react.default.PropTypes;
 var propTypes = {

--- a/test/fixtures/stateless-arrow-return-function/expected-remove-es5.js
+++ b/test/fixtures/stateless-arrow-return-function/expected-remove-es5.js
@@ -5,13 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _react = _interopRequireWildcard(require("react"));
+var _react = babelHelpers.interopRequireWildcard(require("react"));
 
-var _map = _interopRequireDefault(require("lodash/map"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+var _map = babelHelpers.interopRequireDefault(require("lodash/map"));
 
 var Message = function Message(_ref) {
   var mapList = _ref.mapList;

--- a/test/fixtures/stateless-arrow-return-function/expected-wrap-es5.js
+++ b/test/fixtures/stateless-arrow-return-function/expected-wrap-es5.js
@@ -5,13 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _react = _interopRequireWildcard(require("react"));
+var _react = babelHelpers.interopRequireWildcard(require("react"));
 
-var _map = _interopRequireDefault(require("lodash/map"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+var _map = babelHelpers.interopRequireDefault(require("lodash/map"));
 
 var Message = function Message(_ref) {
   var mapList = _ref.mapList;

--- a/test/fixtures/stateless-return-undefined/expected-remove-es5.js
+++ b/test/fixtures/stateless-return-undefined/expected-remove-es5.js
@@ -5,9 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _react = _interopRequireWildcard(require("react"));
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+var _react = babelHelpers.interopRequireWildcard(require("react"));
 
 var Message = function Message(_ref) {
   var isFetching = _ref.isFetching,

--- a/test/fixtures/stateless-return-undefined/expected-wrap-es5.js
+++ b/test/fixtures/stateless-return-undefined/expected-wrap-es5.js
@@ -5,9 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _react = _interopRequireWildcard(require("react"));
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+var _react = babelHelpers.interopRequireWildcard(require("react"));
 
 var Message = function Message(_ref) {
   var isFetching = _ref.isFetching,

--- a/test/fixtures/unsafe-wrap/expected.js
+++ b/test/fixtures/unsafe-wrap/expected.js
@@ -1,31 +1,17 @@
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var Foo1 =
 /*#__PURE__*/
 function (_React$Component) {
-  _inherits(Foo1, _React$Component);
+  babelHelpers.inherits(Foo1, _React$Component);
 
   function Foo1() {
-    _classCallCheck(this, Foo1);
-
-    return _possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo1);
+    return babelHelpers.possibleConstructorReturn(this, (Foo1.__proto__ || Object.getPrototypeOf(Foo1)).apply(this, arguments));
   }
 
-  _createClass(Foo1, [{
+  babelHelpers.createClass(Foo1, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo1;
 }(React.Component);
 
@@ -36,19 +22,17 @@ process.env.NODE_ENV !== "production" ? Foo1.propTypes = {
 var Foo2 =
 /*#__PURE__*/
 function (_React$Component2) {
-  _inherits(Foo2, _React$Component2);
+  babelHelpers.inherits(Foo2, _React$Component2);
 
   function Foo2() {
-    _classCallCheck(this, Foo2);
-
-    return _possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
+    babelHelpers.classCallCheck(this, Foo2);
+    return babelHelpers.possibleConstructorReturn(this, (Foo2.__proto__ || Object.getPrototypeOf(Foo2)).apply(this, arguments));
   }
 
-  _createClass(Foo2, [{
+  babelHelpers.createClass(Foo2, [{
     key: "render",
     value: function render() {}
   }]);
-
   return Foo2;
 }(React.Component);
 

--- a/test/fixtures/variable-comment-annotation/expected-remove-es5.js
+++ b/test/fixtures/variable-comment-annotation/expected-remove-es5.js
@@ -5,15 +5,13 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 
-var _react = _interopRequireDefault(require("react"));
+var _react = babelHelpers.interopRequireDefault(require("react"));
 
-var _propTypes = _interopRequireDefault(require("prop-types"));
+var _propTypes = babelHelpers.interopRequireDefault(require("prop-types"));
 
 var _reactRedux = require("react-redux");
 
-var _FooComponent = _interopRequireDefault(require("./FooComponent"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+var _FooComponent = babelHelpers.interopRequireDefault(require("./FooComponent"));
 
 var Foo = (0, _reactRedux.connect)(function () {}, function () {})(_FooComponent.default);
 var _default = Foo;

--- a/yarn.lock
+++ b/yarn.lock
@@ -217,6 +217,10 @@
   version "7.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/@babel/plugin-check-constants/-/plugin-check-constants-7.0.0-beta.35.tgz#18cca7d9fbba746171c879ced7c69defbdc8bc11"
 
+"@babel/plugin-external-helpers@^7.0.0-beta.35":
+  version "7.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0-beta.35.tgz#ae5992f6f2752a6b12cbf9612060e2c8422d05f8"
+
 "@babel/plugin-proposal-async-generator-functions@7.0.0-beta.35":
   version "7.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.35.tgz#7f55a538b0f347e13504c9301807a16b8b5b5cc9"
@@ -224,7 +228,7 @@
     "@babel/helper-remap-async-to-generator" "7.0.0-beta.35"
     "@babel/plugin-syntax-async-generators" "7.0.0-beta.35"
 
-"@babel/plugin-proposal-class-properties@7.0.0-beta.35":
+"@babel/plugin-proposal-class-properties@7.0.0-beta.35", "@babel/plugin-proposal-class-properties@^7.0.0-beta.35":
   version "7.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.35.tgz#f1c468110959115c7bfd0ba065148048542d06ce"
   dependencies:


### PR DESCRIPTION
Fix detection of placeholders in babel template, seems that the whitelist is only additional to the regular crawling of placeholders. (https://github.com/babel/babel/issues/7035#issuecomment-352246618)

Update everything to latest babel beta.
This also adds babel-plugin-external-helpers in the tests, so that fixtures are not as much dependent on internal babel changes.