### PR TITLE
Add a classNameMatcher option to make component resolution more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,21 @@ additionalLibraries: ['react-immutable-proptypes'],
 ```
 both will be removed.
 
+### `classNameMatchers`
+
+Use this option to enable this plugin to run on components that extend a class different than `React.Component` or `React.PureComponent`.
+
+Given this example:
+```js
+class MyComponent extends BaseComponent {
+  ...
+}
+```
+
+You would use: 
+```js
+classNameMatchers: ["BaseComponent"]
+```
 
 ## Is it safe?
 

--- a/test/fixtures/class-name-matchers-no-match/actual.js
+++ b/test/fixtures/class-name-matchers-no-match/actual.js
@@ -1,0 +1,9 @@
+import BaseComponent from 'components/base'
+
+class Foo extends BaseComponent {
+  render() {}
+}
+
+Foo.propTypes = {
+  bar: PropTypes.string,
+};

--- a/test/fixtures/class-name-matchers-no-match/expected-wrap-es5.js
+++ b/test/fixtures/class-name-matchers-no-match/expected-wrap-es5.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var _base = babelHelpers.interopRequireDefault(require("components/base"));
+
+var Foo =
+/*#__PURE__*/
+function (_BaseComponent) {
+  babelHelpers.inherits(Foo, _BaseComponent);
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+    return babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "render",
+    value: function render() {}
+  }]);
+  return Foo;
+}(_base.default);
+
+Foo.propTypes = {
+  bar: PropTypes.string
+};

--- a/test/fixtures/class-name-matchers-no-match/expected-wrap-es6.js
+++ b/test/fixtures/class-name-matchers-no-match/expected-wrap-es6.js
@@ -1,0 +1,10 @@
+import BaseComponent from 'components/base';
+
+class Foo extends BaseComponent {
+  render() {}
+
+}
+
+Foo.propTypes = {
+  bar: PropTypes.string
+};

--- a/test/fixtures/class-name-matchers/actual.js
+++ b/test/fixtures/class-name-matchers/actual.js
@@ -1,0 +1,9 @@
+import BaseComponent from 'components/base'
+
+class Foo extends BaseComponent {
+  render() {}
+}
+
+Foo.propTypes = {
+  bar: PropTypes.string,
+};

--- a/test/fixtures/class-name-matchers/expected-wrap-es5.js
+++ b/test/fixtures/class-name-matchers/expected-wrap-es5.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var _base = babelHelpers.interopRequireDefault(require("components/base"));
+
+var Foo =
+/*#__PURE__*/
+function (_BaseComponent) {
+  babelHelpers.inherits(Foo, _BaseComponent);
+
+  function Foo() {
+    babelHelpers.classCallCheck(this, Foo);
+    return babelHelpers.possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+  }
+
+  babelHelpers.createClass(Foo, [{
+    key: "render",
+    value: function render() {}
+  }]);
+  return Foo;
+}(_base.default);
+
+Foo.propTypes = process.env.NODE_ENV !== "production" ? {
+  bar: PropTypes.string
+} : {};

--- a/test/fixtures/class-name-matchers/expected-wrap-es6.js
+++ b/test/fixtures/class-name-matchers/expected-wrap-es6.js
@@ -1,0 +1,10 @@
+import BaseComponent from 'components/base';
+
+class Foo extends BaseComponent {
+  render() {}
+
+}
+
+Foo.propTypes = process.env.NODE_ENV !== "production" ? {
+  bar: PropTypes.string
+} : {};

--- a/test/fixtures/class-name-matchers/options.json
+++ b/test/fixtures/class-name-matchers/options.json
@@ -1,0 +1,3 @@
+{
+    "classNameMatchers": ["BaseComponent"]
+}


### PR DESCRIPTION
Hi!

This change would be super helpful for libraries like UI kits where all components extend from a common base class.

If you are ok with adding this extra option, I could write a test for it.

Thanks!



