### PR TITLE
Remove newly unreferenced VariableDeclarators

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/generator": "7.0.0-beta.42",
     "@babel/plugin-external-helpers": "7.0.0-beta.42",
     "@babel/plugin-proposal-class-properties": "7.0.0-beta.42",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-rc.1",
     "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.42",
     "@babel/preset-env": "7.0.0-beta.42",
     "@babel/preset-flow": "7.0.0-beta.42",

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,10 @@ function isReactClass(superClass, scope, globalOptions) {
 }
 
 function areSetsEqual(set1, set2) {
+  if (set1 === set2) {
+    return true
+  }
+
   if (set1.size !== set2.size) {
     return false
   }

--- a/src/remove.js
+++ b/src/remove.js
@@ -101,6 +101,24 @@ export default function remove(path, globalOptions, options) {
         path.node[visitedKey] = true
         break
 
+      case 'declarator':
+        if (mode === 'unsafe-wrap') {
+          path.replaceWith(
+            unsafeWrapTemplate({
+              NODE: path.node,
+            })
+          )
+        } else {
+          path.replaceWith(
+            wrapTemplate({
+              LEFT: path.node.id,
+              RIGHT: path.node.init,
+            })
+          )
+        }
+        path.node[visitedKey] = true
+        break
+
       default:
         break
     }

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -9,6 +9,7 @@ import { transformFileSync } from '@babel/core'
 import babelPluginSyntaxJsx from '@babel/plugin-syntax-jsx'
 import babelPluginExternalHelpers from '@babel/plugin-external-helpers'
 import babelPluginTransformClassProperties from '@babel/plugin-proposal-class-properties'
+import babelPluginProposalObjectRestSpread from '@babel/plugin-proposal-object-rest-spread'
 import babelPluginTransformReactRemovePropTypes from '../src/index'
 import { trim } from './utils'
 
@@ -55,6 +56,7 @@ describe('fixtures', () => {
               babelConfig = {
                 plugins: [
                   babelPluginExternalHelpers,
+                  babelPluginProposalObjectRestSpread,
                   [
                     babelPluginTransformReactRemovePropTypes,
                     {
@@ -70,6 +72,7 @@ describe('fixtures', () => {
               babelConfig = {
                 plugins: [
                   babelPluginExternalHelpers,
+                  babelPluginProposalObjectRestSpread,
                   [
                     babelPluginTransformReactRemovePropTypes,
                     {
@@ -88,6 +91,7 @@ describe('fixtures', () => {
                   babelPluginExternalHelpers,
                   babelPluginSyntaxJsx,
                   babelPluginTransformClassProperties,
+                  babelPluginProposalObjectRestSpread,
                   [
                     babelPluginTransformReactRemovePropTypes,
                     {
@@ -106,6 +110,7 @@ describe('fixtures', () => {
                   babelPluginExternalHelpers,
                   babelPluginSyntaxJsx,
                   babelPluginTransformClassProperties,
+                  babelPluginProposalObjectRestSpread,
                   [
                     babelPluginTransformReactRemovePropTypes,
                     {
@@ -121,6 +126,7 @@ describe('fixtures', () => {
               babelConfig = {
                 plugins: [
                   babelPluginExternalHelpers,
+                  babelPluginProposalObjectRestSpread,
                   [babelPluginTransformReactRemovePropTypes, options],
                 ],
               }

--- a/test/fixtures/es-class-assign-property-variable/actual.js
+++ b/test/fixtures/es-class-assign-property-variable/actual.js
@@ -7,3 +7,13 @@ class Foo extends React.Component {
 }
 
 Foo.propTypes = propTypes;
+
+class Getter extends React.Component {
+  get foo() {
+    return { foo: PropTypes.string };
+  }
+
+  render() {}
+}
+
+Getter.propTypes = Getter.foo;

--- a/test/fixtures/es-class-assign-property-variable/expected-remove-es5.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-remove-es5.js
@@ -1,9 +1,5 @@
 "use strict";
 
-var propTypes = {
-  foo: PropTypes.string
-};
-
 var Foo =
 /*#__PURE__*/
 function (_React$Component) {

--- a/test/fixtures/es-class-assign-property-variable/expected-remove-es5.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-remove-es5.js
@@ -16,3 +16,27 @@ function (_React$Component) {
   }]);
   return Foo;
 }(React.Component);
+
+var Getter =
+/*#__PURE__*/
+function (_React$Component2) {
+  babelHelpers.inherits(Getter, _React$Component2);
+
+  function Getter() {
+    babelHelpers.classCallCheck(this, Getter);
+    return babelHelpers.possibleConstructorReturn(this, (Getter.__proto__ || Object.getPrototypeOf(Getter)).apply(this, arguments));
+  }
+
+  babelHelpers.createClass(Getter, [{
+    key: "render",
+    value: function render() {}
+  }, {
+    key: "foo",
+    get: function get() {
+      return {
+        foo: PropTypes.string
+      };
+    }
+  }]);
+  return Getter;
+}(React.Component);

--- a/test/fixtures/es-class-assign-property-variable/expected-remove-es6.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-remove-es6.js
@@ -2,3 +2,14 @@ class Foo extends React.Component {
   render() {}
 
 }
+
+class Getter extends React.Component {
+  get foo() {
+    return {
+      foo: PropTypes.string
+    };
+  }
+
+  render() {}
+
+}

--- a/test/fixtures/es-class-assign-property-variable/expected-remove-es6.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-remove-es6.js
@@ -1,7 +1,3 @@
-const propTypes = {
-  foo: PropTypes.string
-};
-
 class Foo extends React.Component {
   render() {}
 

--- a/test/fixtures/es-class-assign-property-variable/expected-wrap-es5.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-wrap-es5.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var propTypes = {
+var propTypes = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
-};
+} : {};;
 
 var Foo =
 /*#__PURE__*/

--- a/test/fixtures/es-class-assign-property-variable/expected-wrap-es5.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-wrap-es5.js
@@ -22,3 +22,29 @@ function (_React$Component) {
 }(React.Component);
 
 Foo.propTypes = process.env.NODE_ENV !== "production" ? propTypes : {};
+
+var Getter =
+/*#__PURE__*/
+function (_React$Component2) {
+  babelHelpers.inherits(Getter, _React$Component2);
+
+  function Getter() {
+    babelHelpers.classCallCheck(this, Getter);
+    return babelHelpers.possibleConstructorReturn(this, (Getter.__proto__ || Object.getPrototypeOf(Getter)).apply(this, arguments));
+  }
+
+  babelHelpers.createClass(Getter, [{
+    key: "render",
+    value: function render() {}
+  }, {
+    key: "foo",
+    get: function get() {
+      return {
+        foo: PropTypes.string
+      };
+    }
+  }]);
+  return Getter;
+}(React.Component);
+
+Getter.propTypes = process.env.NODE_ENV !== "production" ? Getter.foo : {};

--- a/test/fixtures/es-class-assign-property-variable/expected-wrap-es6.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-wrap-es6.js
@@ -8,3 +8,16 @@ class Foo extends React.Component {
 }
 
 Foo.propTypes = process.env.NODE_ENV !== "production" ? propTypes : {};
+
+class Getter extends React.Component {
+  get foo() {
+    return {
+      foo: PropTypes.string
+    };
+  }
+
+  render() {}
+
+}
+
+Getter.propTypes = process.env.NODE_ENV !== "production" ? Getter.foo : {};

--- a/test/fixtures/es-class-assign-property-variable/expected-wrap-es6.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-wrap-es6.js
@@ -1,6 +1,6 @@
-const propTypes = {
+const propTypes = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
-};
+} : {};;
 
 class Foo extends React.Component {
   render() {}

--- a/test/fixtures/variable-assignment/actual.js
+++ b/test/fixtures/variable-assignment/actual.js
@@ -1,0 +1,53 @@
+const propTypesBasic = {
+  foo: PropTypes.string
+};
+
+const FooBasic = () => (
+  <div />
+);
+
+FooBasic.propTypes = propTypesBasic;
+
+const extraReference = {
+  bar: PropTypes.string
+};
+
+const propTypesWithExtraReference = Object.assign({}, extraReference, {
+  foo: PropTypes.string
+});
+
+const FooExtraReference = () => (
+  <div />
+);
+
+FooExtraReference.propTypes = propTypesWithExtraReference;
+
+const propTypesWrapped = {
+  foo: PropTypes.string
+};
+
+const FooWrapped = () => (
+  <div />
+);
+
+FooWrapped.propTypes = someWrappingFunction(propTypesWrapped);
+
+const propTypesReferenced = {
+  foo: PropTypes.string
+};
+
+const FooReferenced = () => (
+  <div bar={propTypesReferenced} />
+);
+
+FooReferenced.propTypes = propTypesReferenced;
+
+export const propTypesExported = {
+  foo: PropTypes.string
+};
+
+const FooExported = () => (
+  <div />
+);
+
+FooExported.propTypes = propTypesExported;

--- a/test/fixtures/variable-assignment/actual.js
+++ b/test/fixtures/variable-assignment/actual.js
@@ -63,3 +63,8 @@ const FooExported = () => (
 );
 
 FooExported.propTypes = propTypesExported;
+
+const propTypesCreateClass = { foo: PropTypes.string };
+const FooCreateClass = createReactClass({
+  propTypes: propTypesCreateClass
+});

--- a/test/fixtures/variable-assignment/actual.js
+++ b/test/fixtures/variable-assignment/actual.js
@@ -22,6 +22,18 @@ const FooExtraReference = () => (
 
 FooExtraReference.propTypes = propTypesWithExtraReference;
 
+const propTypesWithExtraReferenceSpread = {
+  ...extraReference,
+  ...({ foo: PropTypes.string }),
+  bar: PropTypes.string
+};
+
+const FooExtraReferenceSpread = () => (
+  <div />
+);
+
+FooExtraReferenceSpread.propTypes = propTypesWithExtraReferenceSpread;
+
 const propTypesWrapped = {
   foo: PropTypes.string
 };

--- a/test/fixtures/variable-assignment/expected-remove-es5.js
+++ b/test/fixtures/variable-assignment/expected-remove-es5.js
@@ -13,6 +13,10 @@ var FooExtraReference = function FooExtraReference() {
   return React.createElement("div", null);
 };
 
+var FooExtraReferenceSpread = function FooExtraReferenceSpread() {
+  return React.createElement("div", null);
+};
+
 var FooWrapped = function FooWrapped() {
   return React.createElement("div", null);
 };

--- a/test/fixtures/variable-assignment/expected-remove-es5.js
+++ b/test/fixtures/variable-assignment/expected-remove-es5.js
@@ -1,0 +1,37 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.propTypesExported = void 0;
+
+var FooBasic = function FooBasic() {
+  return React.createElement("div", null);
+};
+
+var FooExtraReference = function FooExtraReference() {
+  return React.createElement("div", null);
+};
+
+var FooWrapped = function FooWrapped() {
+  return React.createElement("div", null);
+};
+
+var propTypesReferenced = {
+  foo: PropTypes.string
+};
+
+var FooReferenced = function FooReferenced() {
+  return React.createElement("div", {
+    bar: propTypesReferenced
+  });
+};
+
+var propTypesExported = {
+  foo: PropTypes.string
+};
+exports.propTypesExported = propTypesExported;
+
+var FooExported = function FooExported() {
+  return React.createElement("div", null);
+};

--- a/test/fixtures/variable-assignment/expected-remove-es5.js
+++ b/test/fixtures/variable-assignment/expected-remove-es5.js
@@ -39,3 +39,7 @@ exports.propTypesExported = propTypesExported;
 var FooExported = function FooExported() {
   return React.createElement("div", null);
 };
+
+var FooCreateClass = createReactClass({
+  displayName: "FooCreateClass"
+});

--- a/test/fixtures/variable-assignment/expected-remove-es6.js
+++ b/test/fixtures/variable-assignment/expected-remove-es6.js
@@ -2,6 +2,8 @@ const FooBasic = () => <div />;
 
 const FooExtraReference = () => <div />;
 
+const FooExtraReferenceSpread = () => <div />;
+
 const FooWrapped = () => <div />;
 
 const propTypesReferenced = {

--- a/test/fixtures/variable-assignment/expected-remove-es6.js
+++ b/test/fixtures/variable-assignment/expected-remove-es6.js
@@ -17,3 +17,5 @@ export const propTypesExported = {
 };
 
 const FooExported = () => <div />;
+
+const FooCreateClass = createReactClass({});

--- a/test/fixtures/variable-assignment/expected-remove-es6.js
+++ b/test/fixtures/variable-assignment/expected-remove-es6.js
@@ -1,0 +1,17 @@
+const FooBasic = () => <div />;
+
+const FooExtraReference = () => <div />;
+
+const FooWrapped = () => <div />;
+
+const propTypesReferenced = {
+  foo: PropTypes.string
+};
+
+const FooReferenced = () => <div bar={propTypesReferenced} />;
+
+export const propTypesExported = {
+  foo: PropTypes.string
+};
+
+const FooExported = () => <div />;

--- a/test/fixtures/variable-assignment/expected-wrap-es5.js
+++ b/test/fixtures/variable-assignment/expected-wrap-es5.js
@@ -25,6 +25,17 @@ var FooExtraReference = function FooExtraReference() {
 };
 
 FooExtraReference.propTypes = process.env.NODE_ENV !== "production" ? propTypesWithExtraReference : {};
+var propTypesWithExtraReferenceSpread = process.env.NODE_ENV !== "production" ? babelHelpers.objectSpread({}, extraReference, {
+  foo: PropTypes.string
+}, {
+  bar: PropTypes.string
+}) : {};;
+
+var FooExtraReferenceSpread = function FooExtraReferenceSpread() {
+  return React.createElement("div", null);
+};
+
+FooExtraReferenceSpread.propTypes = process.env.NODE_ENV !== "production" ? propTypesWithExtraReferenceSpread : {};
 var propTypesWrapped = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
 } : {};;

--- a/test/fixtures/variable-assignment/expected-wrap-es5.js
+++ b/test/fixtures/variable-assignment/expected-wrap-es5.js
@@ -1,0 +1,58 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.propTypesExported = void 0;
+var propTypesBasic = process.env.NODE_ENV !== "production" ? {
+  foo: PropTypes.string
+} : {};;
+
+var FooBasic = function FooBasic() {
+  return React.createElement("div", null);
+};
+
+FooBasic.propTypes = process.env.NODE_ENV !== "production" ? propTypesBasic : {};
+var extraReference = process.env.NODE_ENV !== "production" ? {
+  bar: PropTypes.string
+} : {};;
+var propTypesWithExtraReference = process.env.NODE_ENV !== "production" ? Object.assign({}, extraReference, {
+  foo: PropTypes.string
+}) : {};;
+
+var FooExtraReference = function FooExtraReference() {
+  return React.createElement("div", null);
+};
+
+FooExtraReference.propTypes = process.env.NODE_ENV !== "production" ? propTypesWithExtraReference : {};
+var propTypesWrapped = process.env.NODE_ENV !== "production" ? {
+  foo: PropTypes.string
+} : {};;
+
+var FooWrapped = function FooWrapped() {
+  return React.createElement("div", null);
+};
+
+FooWrapped.propTypes = process.env.NODE_ENV !== "production" ? someWrappingFunction(propTypesWrapped) : {};
+var propTypesReferenced = {
+  foo: PropTypes.string
+};
+
+var FooReferenced = function FooReferenced() {
+  return React.createElement("div", {
+    bar: propTypesReferenced
+  });
+};
+
+FooReferenced.propTypes = process.env.NODE_ENV !== "production" ? propTypesReferenced : {};
+var propTypesExported = {
+  foo: PropTypes.string
+};
+exports.propTypesExported = propTypesExported;
+
+var FooExported = function FooExported() {
+  return React.createElement("div", null);
+};
+
+FooExported.propTypes = process.env.NODE_ENV !== "production" ? propTypesExported : {};
+

--- a/test/fixtures/variable-assignment/expected-wrap-es5.js
+++ b/test/fixtures/variable-assignment/expected-wrap-es5.js
@@ -66,4 +66,10 @@ var FooExported = function FooExported() {
 };
 
 FooExported.propTypes = process.env.NODE_ENV !== "production" ? propTypesExported : {};
-
+var propTypesCreateClass = process.env.NODE_ENV !== "production" ? {
+  foo: PropTypes.string
+} : {};;
+var FooCreateClass = createReactClass({
+  displayName: "FooCreateClass",
+  propTypes: propTypesCreateClass
+});

--- a/test/fixtures/variable-assignment/expected-wrap-es6.js
+++ b/test/fixtures/variable-assignment/expected-wrap-es6.js
@@ -45,3 +45,9 @@ export const propTypesExported = {
 const FooExported = () => <div />;
 
 FooExported.propTypes = process.env.NODE_ENV !== "production" ? propTypesExported : {};
+const propTypesCreateClass = process.env.NODE_ENV !== "production" ? {
+  foo: PropTypes.string
+} : {};;
+const FooCreateClass = createReactClass({
+  propTypes: propTypesCreateClass
+});

--- a/test/fixtures/variable-assignment/expected-wrap-es6.js
+++ b/test/fixtures/variable-assignment/expected-wrap-es6.js
@@ -1,0 +1,38 @@
+const propTypesBasic = process.env.NODE_ENV !== "production" ? {
+  foo: PropTypes.string
+} : {};;
+
+const FooBasic = () => <div />;
+
+FooBasic.propTypes = process.env.NODE_ENV !== "production" ? propTypesBasic : {};
+const extraReference = process.env.NODE_ENV !== "production" ? {
+  bar: PropTypes.string
+} : {};;
+const propTypesWithExtraReference = process.env.NODE_ENV !== "production" ? Object.assign({}, extraReference, {
+  foo: PropTypes.string
+}) : {};;
+
+const FooExtraReference = () => <div />;
+
+FooExtraReference.propTypes = process.env.NODE_ENV !== "production" ? propTypesWithExtraReference : {};
+const propTypesWrapped = process.env.NODE_ENV !== "production" ? {
+  foo: PropTypes.string
+} : {};;
+
+const FooWrapped = () => <div />;
+
+FooWrapped.propTypes = process.env.NODE_ENV !== "production" ? someWrappingFunction(propTypesWrapped) : {};
+const propTypesReferenced = {
+  foo: PropTypes.string
+};
+
+const FooReferenced = () => <div bar={propTypesReferenced} />;
+
+FooReferenced.propTypes = process.env.NODE_ENV !== "production" ? propTypesReferenced : {};
+export const propTypesExported = {
+  foo: PropTypes.string
+};
+
+const FooExported = () => <div />;
+
+FooExported.propTypes = process.env.NODE_ENV !== "production" ? propTypesExported : {};

--- a/test/fixtures/variable-assignment/expected-wrap-es6.js
+++ b/test/fixtures/variable-assignment/expected-wrap-es6.js
@@ -15,6 +15,15 @@ const propTypesWithExtraReference = process.env.NODE_ENV !== "production" ? Obje
 const FooExtraReference = () => <div />;
 
 FooExtraReference.propTypes = process.env.NODE_ENV !== "production" ? propTypesWithExtraReference : {};
+const propTypesWithExtraReferenceSpread = process.env.NODE_ENV !== "production" ? babelHelpers.objectSpread({}, extraReference, {
+  foo: PropTypes.string
+}, {
+  bar: PropTypes.string
+}) : {};;
+
+const FooExtraReferenceSpread = () => <div />;
+
+FooExtraReferenceSpread.propTypes = process.env.NODE_ENV !== "production" ? propTypesWithExtraReferenceSpread : {};
 const propTypesWrapped = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
 } : {};;


### PR DESCRIPTION
I've noticed that a common pattern used to assign propTypes--first
define a variable for the propTypes, and then assign it to the component
by reference--ends up deoptimizing this plugin, which leads to larger
bundles in production than desired. The original hypothesis that
minification would clean up these dead references works well for the
simplest of propTypes, but unfortunately it doesn't hold up as
soon as you have a function call in the propTypes variable (such as is
the case for propTypes like `arrayOf`, `objectOf`, `shape`, etc.)
because the minfier does not know that the function call will not have
side-effects:

```js
const propTypes = {
  foo: PropTypes.arrayOf(PropTypes.number),
};
```

I believe this should be solved by this plugin because we can make the
assumption that function calls inside of propTypes have no side-effects.

There seems to be a weird issue where the transform adds a semicolon
when using in wrapped mode. For now, I decided to simply add the
additional semicolons in the test fixtures, since they will be minified
out anyway.

I don't have much experience working with Babel plugins yet, so it is
likely that I'm doing things in a weird or sub-optimal way here.

Fixes #145 