### PR TITLE
Replace Set with WeakSet for collecting removed paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export default function(api) {
   const { template, types, traverse } = api
 
   const nestedIdentifiers = new Set()
-  const removedPaths = new Set()
+  const removedPaths = new WeakSet()
   const collectNestedIdentifiers = {
     Identifier(path) {
       if (path.parent.type === 'MemberExpression') {


### PR DESCRIPTION
This contains objects and is never traversed, so we might be able to
help free us some memory by using a WeakSet here instead of a Set.

cc @ljharb