### PR TITLE
Use regex.test(str) instead of str.match(regex)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ function isPathReactClass(path, globalOptions) {
     return true
   }
 
-  if (node && matchers && node.name.match(matchers)) {
+  if (node && matchers && matchers.test(node.name)) {
     return true
   }
 
@@ -97,13 +97,13 @@ export default function(api) {
         let classNameMatchers
 
         if (state.opts.ignoreFilenames) {
-          ignoreFilenames = new RegExp(state.opts.ignoreFilenames.join('|'), 'gi')
+          ignoreFilenames = new RegExp(state.opts.ignoreFilenames.join('|'), 'i')
         } else {
           ignoreFilenames = undefined
         }
 
         if (state.opts.classNameMatchers) {
-          classNameMatchers = new RegExp(state.opts.classNameMatchers.join('|'), 'g')
+          classNameMatchers = new RegExp(state.opts.classNameMatchers.join('|'))
         } else {
           classNameMatchers = undefined
         }

--- a/src/remove.js
+++ b/src/remove.js
@@ -12,7 +12,11 @@ function isInside(scope, regex) {
     return true
   }
 
-  return filename.match(regex) !== null
+  if (!regex) {
+    return false
+  }
+
+  return regex.test(filename)
 }
 
 // Remove a specific path.


### PR DESCRIPTION
This method returns a boolean so it should be faster and more memory
efficient.

In order to make this work, I needed to remove the global flag from the
regexes, because that makes the regexes mutable when run multiple times.
Since these are only used to test for any match, and not for any
matching groups or in any other way, we don't need this flag.

cc @ljharb