### PR TITLE
Add failing test case for #153

### DIFF
--- a/src/remove.js
+++ b/src/remove.js
@@ -60,15 +60,19 @@ export default function remove(path, globalOptions, options) {
 
       // Inspired from babel-plugin-transform-class-properties.
       case 'class static': {
-        let ref
         let pathClassDeclaration = options.pathClassDeclaration
 
-        if (!pathClassDeclaration.isClassExpression() && pathClassDeclaration.node.id) {
-          ref = pathClassDeclaration.node.id
-        } else {
+        if (!pathClassDeclaration.node.id) {
           // Class without name not supported
           return
         }
+
+        if (pathClassDeclaration.isClassExpression()) {
+          // () => class Foo {}
+          return
+        }
+
+        const ref = pathClassDeclaration.node.id
 
         const node = types.expressionStatement(
           types.assignmentExpression(

--- a/test/fixtures/es-class-static-property/actual.js
+++ b/test/fixtures/es-class-static-property/actual.js
@@ -13,3 +13,13 @@ export default class Foo2 extends React.Component {
 
   render() {}
 }
+
+const componentFactory = () => {
+  return class Foo3 extends React.Component {
+    static propTypes = {
+      bar3: PropTypes.string,
+    }
+
+    render() {}
+  };
+};

--- a/test/fixtures/es-class-static-property/expected-remove-es5.js
+++ b/test/fixtures/es-class-static-property/expected-remove-es5.js
@@ -40,3 +40,23 @@ function (_React$Component2) {
 }(React.Component);
 
 exports.default = Foo2;
+
+var componentFactory = function componentFactory() {
+  return (
+    /*#__PURE__*/
+    function (_React$Component3) {
+      babelHelpers.inherits(Foo3, _React$Component3);
+
+      function Foo3() {
+        babelHelpers.classCallCheck(this, Foo3);
+        return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo3).apply(this, arguments));
+      }
+
+      babelHelpers.createClass(Foo3, [{
+        key: "render",
+        value: function render() {}
+      }]);
+      return Foo3;
+    }(React.Component)
+  );
+};

--- a/test/fixtures/es-class-static-property/expected-remove-es6.js
+++ b/test/fixtures/es-class-static-property/expected-remove-es6.js
@@ -7,3 +7,10 @@ export default class Foo2 extends React.Component {
   render() {}
 
 }
+
+const componentFactory = () => {
+  return class Foo3 extends React.Component {
+    render() {}
+
+  };
+};

--- a/test/fixtures/es-class-static-property/expected-wrap-es5.js
+++ b/test/fixtures/es-class-static-property/expected-wrap-es5.js
@@ -47,3 +47,26 @@ exports.default = Foo2;
 Foo2.propTypes = process.env.NODE_ENV !== "production" ? {
   bar2: PropTypes.string
 } : {};
+
+var componentFactory = function componentFactory() {
+  var _temp;
+
+  return _temp =
+  /*#__PURE__*/
+  function (_React$Component3) {
+    babelHelpers.inherits(Foo3, _React$Component3);
+
+    function Foo3() {
+      babelHelpers.classCallCheck(this, Foo3);
+      return babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Foo3).apply(this, arguments));
+    }
+
+    babelHelpers.createClass(Foo3, [{
+      key: "render",
+      value: function render() {}
+    }]);
+    return Foo3;
+  }(React.Component), Foo3.propTypes = process.env.NODE_ENV !== "production" ? {
+    bar3: PropTypes.string
+  } : {}, _temp;
+};

--- a/test/fixtures/es-class-static-property/expected-wrap-es6.js
+++ b/test/fixtures/es-class-static-property/expected-wrap-es6.js
@@ -13,3 +13,14 @@ export default class Foo2 extends React.Component {
 Foo2.propTypes = process.env.NODE_ENV !== "production" ? {
   bar2: PropTypes.string
 } : {};
+
+const componentFactory = () => {
+  var _temp;
+
+  return _temp = class Foo3 extends React.Component {
+    render() {}
+
+  }, Foo3.propTypes = process.env.NODE_ENV !== "production" ? {
+    bar3: PropTypes.string
+  } : {}, _temp;
+};


### PR DESCRIPTION
I have been investigating a bug that occurs when a ClassExpression is
using the experimental class properties for propTypes. I am not sure
what the best fix for it is yet, but I wanted to get up a failing test
case to help showcase the bug.

@oliviertassinari do you have any ideas on how static class propTypes
properties can be removed from ClassExpressions in wrap mode?

Related to #153