### PR TITLE
Added handling for removing propTypes from babel output code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -211,7 +211,8 @@ export default function(api) {
                   return false
                 }
 
-                return currentNode.get('callee').node.name === 'createReactClass'
+                return currentNode.get('callee').node.name === 'createReactClass' ||
+                        currentNode.get('callee').node.property.name === 'createClass';
               })
 
               if (parent) {


### PR DESCRIPTION
So this is a third party library that ships their compiled code with propTypes, with this change it will removed.