### PR TITLE
Include babel core as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "bugs": {
     "url": "https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/issues"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0-0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.1.0",
     "@babel/core": "^7.1.0",


### PR DESCRIPTION
Since `@babel/core` is needed to use this plugin, it's good to include it as a peer dependency. (I followed the same [way `babel` does it](https://github.com/babel/babel/blob/master/packages/babel-plugin-external-helpers/package.json#L18).)

It's also a good idea to keep that for anyone unsure whether this plugin supports `babel` 6 or `babel` 7.