### PR TITLE
Fix extraneous semicolon

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -152,12 +152,23 @@ export default function(api) {
             `,
             { placeholderPattern: /^NODE$/ }
           ),
-          wrapTemplate: template(
-            `
-              LEFT = process.env.NODE_ENV !== "production" ? RIGHT : {}
-            `,
-            { placeholderPattern: /^(LEFT|RIGHT)$/ }
-          ),
+          wrapTemplate: ({ LEFT, RIGHT }, options = {}) => {
+            const { as = 'assignmentExpression' } = options
+            const right = template.expression(
+              `
+                process.env.NODE_ENV !== "production" ? RIGHT : {}
+              `,
+              { placeholderPattern: /^(LEFT|RIGHT)$/ }
+            )({ RIGHT })
+            switch (as) {
+              case 'variableDeclarator':
+                return types.variableDeclarator(LEFT, right)
+              case 'assignmentExpression':
+                return types.assignmentExpression('=', LEFT, right)
+              default:
+                throw new Error(`unrecognized template type ${as}`)
+            }
+          },
           mode: state.opts.mode || 'remove',
           ignoreFilenames,
           types,

--- a/src/remove.js
+++ b/src/remove.js
@@ -113,10 +113,13 @@ export default function remove(path, globalOptions, options) {
           )
         } else {
           path.replaceWith(
-            wrapTemplate({
-              LEFT: path.node.id,
-              RIGHT: path.node.init,
-            })
+            wrapTemplate(
+              {
+                LEFT: path.node.id,
+                RIGHT: path.node.init,
+              },
+              { as: 'variableDeclarator' }
+            )
           )
         }
         path.node[visitedKey] = true

--- a/test/fixtures/const-in-anonymous-validator/expected-wrap-es5.js
+++ b/test/fixtures/const-in-anonymous-validator/expected-wrap-es5.js
@@ -16,7 +16,7 @@ var referencedPropTypes = process.env.NODE_ENV !== "production" ? {
     var willBeWrapped = 1;
     return null;
   }
-} : {};;
+} : {};
 Component.propTypes = process.env.NODE_ENV !== "production" ? babelHelpers.objectSpread({
   variant1: function variant1(props) {
     var variants = [null];

--- a/test/fixtures/const-in-anonymous-validator/expected-wrap-es6.js
+++ b/test/fixtures/const-in-anonymous-validator/expected-wrap-es6.js
@@ -7,7 +7,7 @@ const referencedPropTypes = process.env.NODE_ENV !== "production" ? {
     const willBeWrapped = 1;
     return null;
   }
-} : {};;
+} : {};
 Component.propTypes = process.env.NODE_ENV !== "production" ? babelHelpers.objectSpread({
   variant1: props => {
     const variants = [null];

--- a/test/fixtures/es-class-assign-property-variable/expected-wrap-es5.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-wrap-es5.js
@@ -2,7 +2,7 @@
 
 var propTypes = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
-} : {};;
+} : {};
 
 var Foo =
 /*#__PURE__*/

--- a/test/fixtures/es-class-assign-property-variable/expected-wrap-es6.js
+++ b/test/fixtures/es-class-assign-property-variable/expected-wrap-es6.js
@@ -1,6 +1,6 @@
 const propTypes = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
-} : {};;
+} : {};
 
 class Foo extends React.Component {
   render() {}

--- a/test/fixtures/variable-assignment-member-expressions/expected-wrap-es5.js
+++ b/test/fixtures/variable-assignment-member-expressions/expected-wrap-es5.js
@@ -2,7 +2,7 @@
 
 var shapePropType = process.env.NODE_ENV !== "production" ? PropTypes.shape({
   foo: PropTypes.string
-}) : {};;
+}) : {};
 
 var ComponentA = function ComponentA() {
   return React.createElement("div", null);
@@ -14,7 +14,7 @@ ComponentA.propTypes = process.env.NODE_ENV !== "production" ? {
 var somePropTypes = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string,
   bar: PropTypes.number
-} : {};;
+} : {};
 
 var ComponentB = function ComponentB() {
   return React.createElement("div", null);
@@ -26,7 +26,7 @@ ComponentB.propTypes = process.env.NODE_ENV !== "production" ? {
 var somePropTypesC = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string,
   bar: PropTypes.number
-} : {};;
+} : {};
 
 var ComponentC = function ComponentC() {
   return React.createElement("div", null);
@@ -38,7 +38,7 @@ ComponentC.propTypes = process.env.NODE_ENV !== "production" ? {
 var somePropTypesD = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string,
   bar: PropTypes.number
-} : {};;
+} : {};
 
 var ComponentD = function ComponentD() {
   return React.createElement("div", null);

--- a/test/fixtures/variable-assignment-member-expressions/expected-wrap-es6.js
+++ b/test/fixtures/variable-assignment-member-expressions/expected-wrap-es6.js
@@ -1,6 +1,6 @@
 const shapePropType = process.env.NODE_ENV !== "production" ? PropTypes.shape({
   foo: PropTypes.string
-}) : {};;
+}) : {};
 
 const ComponentA = () => <div />;
 
@@ -10,7 +10,7 @@ ComponentA.propTypes = process.env.NODE_ENV !== "production" ? {
 const somePropTypes = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string,
   bar: PropTypes.number
-} : {};;
+} : {};
 
 const ComponentB = () => <div />;
 
@@ -20,7 +20,7 @@ ComponentB.propTypes = process.env.NODE_ENV !== "production" ? {
 const somePropTypesC = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string,
   bar: PropTypes.number
-} : {};;
+} : {};
 
 const ComponentC = () => <div />;
 
@@ -30,7 +30,7 @@ ComponentC.propTypes = process.env.NODE_ENV !== "production" ? {
 const somePropTypesD = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string,
   bar: PropTypes.number
-} : {};;
+} : {};
 
 const ComponentD = () => <div />;
 

--- a/test/fixtures/variable-assignment/expected-wrap-es5.js
+++ b/test/fixtures/variable-assignment/expected-wrap-es5.js
@@ -6,7 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.propTypesExported = void 0;
 var propTypesBasic = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
-} : {};;
+} : {};
 
 var FooBasic = function FooBasic() {
   return React.createElement("div", null);
@@ -15,10 +15,10 @@ var FooBasic = function FooBasic() {
 FooBasic.propTypes = process.env.NODE_ENV !== "production" ? propTypesBasic : {};
 var extraReference = process.env.NODE_ENV !== "production" ? {
   bar: PropTypes.string
-} : {};;
+} : {};
 var propTypesWithExtraReference = process.env.NODE_ENV !== "production" ? Object.assign({}, extraReference, {
   foo: PropTypes.string
-}) : {};;
+}) : {};
 
 var FooExtraReference = function FooExtraReference() {
   return React.createElement("div", null);
@@ -29,7 +29,7 @@ var propTypesWithExtraReferenceSpread = process.env.NODE_ENV !== "production" ? 
   foo: PropTypes.string
 }, {
   bar: PropTypes.string
-}) : {};;
+}) : {};
 
 var FooExtraReferenceSpread = function FooExtraReferenceSpread() {
   return React.createElement("div", null);
@@ -38,7 +38,7 @@ var FooExtraReferenceSpread = function FooExtraReferenceSpread() {
 FooExtraReferenceSpread.propTypes = process.env.NODE_ENV !== "production" ? propTypesWithExtraReferenceSpread : {};
 var propTypesWrapped = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
-} : {};;
+} : {};
 
 var FooWrapped = function FooWrapped() {
   return React.createElement("div", null);
@@ -68,7 +68,7 @@ var FooExported = function FooExported() {
 FooExported.propTypes = process.env.NODE_ENV !== "production" ? propTypesExported : {};
 var propTypesCreateClass = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
-} : {};;
+} : {};
 var FooCreateClass = createReactClass({
   displayName: "FooCreateClass",
   propTypes: propTypesCreateClass

--- a/test/fixtures/variable-assignment/expected-wrap-es6.js
+++ b/test/fixtures/variable-assignment/expected-wrap-es6.js
@@ -1,16 +1,16 @@
 const propTypesBasic = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
-} : {};;
+} : {};
 
 const FooBasic = () => <div />;
 
 FooBasic.propTypes = process.env.NODE_ENV !== "production" ? propTypesBasic : {};
 const extraReference = process.env.NODE_ENV !== "production" ? {
   bar: PropTypes.string
-} : {};;
+} : {};
 const propTypesWithExtraReference = process.env.NODE_ENV !== "production" ? Object.assign({}, extraReference, {
   foo: PropTypes.string
-}) : {};;
+}) : {};
 
 const FooExtraReference = () => <div />;
 
@@ -19,14 +19,14 @@ const propTypesWithExtraReferenceSpread = process.env.NODE_ENV !== "production" 
   foo: PropTypes.string
 }, {
   bar: PropTypes.string
-}) : {};;
+}) : {};
 
 const FooExtraReferenceSpread = () => <div />;
 
 FooExtraReferenceSpread.propTypes = process.env.NODE_ENV !== "production" ? propTypesWithExtraReferenceSpread : {};
 const propTypesWrapped = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
-} : {};;
+} : {};
 
 const FooWrapped = () => <div />;
 
@@ -47,7 +47,7 @@ const FooExported = () => <div />;
 FooExported.propTypes = process.env.NODE_ENV !== "production" ? propTypesExported : {};
 const propTypesCreateClass = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
-} : {};;
+} : {};
 const FooCreateClass = createReactClass({
   propTypes: propTypesCreateClass
 });


### PR DESCRIPTION
Followup on #167

This was caused because the transformed AST was invalid when VariableDeclarator was wrapped because it returned an AssignmentExpression that was used as the variableDeclarator for a VariableDeclaration.

To be more specific it previously created nodes similar to this:
```json
{
  "type": "VariableDeclaration",
  "declarations": [
    {
      "type": "ExpressionStatement",
      "expression": {
        "type": "AssignmentExpression",
        "operator": "=",
        "left": {
          "type": "Identifier",
          "loc": {
            "identifierName": "referencedPropTypes"
          },
          "name": "referencedPropTypes"
        },
        "right": {
          "type": "ConditionalExpression",
          "test": {},
          "consequent": {},
          "alternate": {}
        }
      },
    }
  ],
  "kind": "const"
},
```
```js
const referencedPropTypes = process.env.NODE_ENV !== "production" ? {} : {};;
```
which would never be created by any parser but `@babel/generator` is robust enough to handle it.

Now we get a valid AST:
```json
{
  "type": "VariableDeclaration",
  "declarations": [
    {
      "type": "VariableDeclarator",
      "id": {
        "type": "Identifier",
        "loc": {
          "identifierName": "referencedPropTypes"
        },
        "name": "referencedPropTypes"
      },
      "init": {
        "type": "ConditionalExpression",
        "test": {},
        "consequent": {},
        "alternate": {},
        "extra": {
          "parenthesized": true,
          "parenStart": 0
        }
      }
    }
  ],
  "kind": "const"
},
```
```js
const referencedPropTypes = process.env.NODE_ENV !== "production" ? {} : {};
```