### PR TITLE
 Add support for defining additionalLibraries as a regexp expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 # No npm lockfiles
 npm-shrinkwrap.json
 package-lock.json
+
+# JetBrains IDE
+.idea

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ both will be removed.
 
 #### Regular expressions
 
-If you are using Babel 7 or newer and your config is written as a javascript module (and not static JSON file), you can also use a regular expression to describe modules, which should be removed.
+If you are using Babel 7 or newer and your config is stored in [`babel.config.js`](https://babeljs.io/docs/en/configuration#babelconfigjs), you can also use a regular expression to describe modules, which should be removed.
 
 This would be particularly useful when using custom prop types validators, implemented as part of your own source code. For example
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,35 @@ additionalLibraries: ['react-immutable-proptypes'],
 ```
 both will be removed.
 
+#### Regular expressions
+
+If you are using Babel 7 or newer and your config is written as a javascript module (and not static JSON file), you can also use a regular expression to describe modules, which should be removed.
+
+This would be particularly useful when using custom prop types validators, implemented as part of your own source code. For example
+
+```js
+import CustomPropTypes from '../../prop-types/my-own-validator.js'
+import OtherCustomPropTypes from '../../prop-types/my-other-validator.js'
+```
+
+would be removed with following setting
+
+```js
+additionalLibraries: [/\/prop-types\/.*\.js$/]
+```
+
+If you use an index file
+
+```js
+import CustomPropTypes from '../../prop-types'
+```
+
+you could set it up as
+
+```js
+additionalLibraries: [/\/prop-types$/]
+```
+
 ### `classNameMatchers`
 
 Use this option to enable this plugin to run on components that extend a class different than `React.Component` or `React.PureComponent`.

--- a/README.md
+++ b/README.md
@@ -187,14 +187,14 @@ If you are using Babel 7 or newer and your config is stored in [`babel.config.js
 This would be particularly useful when using custom prop types validators, implemented as part of your own source code. For example
 
 ```js
-import CustomPropTypes from '../../prop-types/my-own-validator.js'
-import OtherCustomPropTypes from '../../prop-types/my-other-validator.js'
+import CustomPropTypes from '../../prop-types/my-own-validator'
+import OtherCustomPropTypes from '../../prop-types/my-other-validator'
 ```
 
-would be removed with following setting
+would be removed with the following setting
 
 ```js
-additionalLibraries: [/\/prop-types\/.*\.js$/]
+additionalLibraries: [/\/prop-types\/.*$/]
 ```
 
 If you use an index file

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-prettier": "^2.3.1",
     "eslint-plugin-react": "^7.4.0",
+    "globby": "^8.0.1",
     "mocha": "^4.0.1",
-    "path-exists": "^3.0.0",
     "pkgfiles": "^2.3.2",
     "prettier": "^1.14.3"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -361,9 +361,19 @@ export default function(api) {
             programPath.traverse({
               ImportDeclaration(path) {
                 const { source, specifiers } = path.node
-                if (globalOptions.libraries.indexOf(source.value) === -1) {
+
+                const found = globalOptions.libraries.some(library => {
+                  if (library instanceof RegExp) {
+                    return library.test(source.value)
+                  }
+
+                  return source.value === library
+                })
+
+                if (!found) {
                   return
                 }
+
                 const haveUsedSpecifiers = specifiers.some(specifier => {
                   const importedIdentifierName = specifier.local.name
                   const { referencePaths } = path.scope.getBinding(importedIdentifierName)

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -3,8 +3,8 @@
 
 import path from 'path'
 import fs from 'fs'
+import globby from 'globby'
 import { assert } from 'chai'
-import pathExists from 'path-exists'
 import { transformFileSync } from '@babel/core'
 import babelPluginSyntaxJsx from '@babel/plugin-syntax-jsx'
 import babelPluginExternalHelpers from '@babel/plugin-external-helpers'
@@ -31,10 +31,11 @@ describe('fixtures', () => {
         let expected
         let options = {}
 
-        const optionsPath = path.join(fixtureDir, 'options.json')
-        if (pathExists.sync(optionsPath)) {
+        const optionsPaths = globby.sync(path.join(fixtureDir, 'options.{js,json}'))
+
+        optionsPaths.forEach(optionsPath => {
           options = require(optionsPath) // eslint-disable-line global-require, import/no-dynamic-require
-        }
+        })
 
         const filename = mode === 'options' ? 'expected.js' : `expected-${mode}.js`
 

--- a/test/fixtures/additional-libraries-regexp/actual.js
+++ b/test/fixtures/additional-libraries-regexp/actual.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import CustomPropTypes from './custom-prop-types'
+
+export default class Greeting extends Component {
+  constructor (props, context) {
+    super(props, context)
+    const appName = context.store.getState().appName
+    this.state = {
+      appName: appName
+    }
+  }
+
+  render () {
+    return <h1>Welcome {this.props.name} and {this.props.friends.join(', ')} to {this.state.appName}</h1>;
+  }
+}
+
+Greeting.propTypes = {
+  name: PropTypes.string.isRequired,
+  friends: CustomPropTypes.customValidator
+}

--- a/test/fixtures/additional-libraries-regexp/custom-prop-types.js
+++ b/test/fixtures/additional-libraries-regexp/custom-prop-types.js
@@ -1,0 +1,6 @@
+const customValidator = (props, propName, componentName) => {
+}
+
+export default {
+  customValidator
+}

--- a/test/fixtures/additional-libraries-regexp/expected-remove-es5.js
+++ b/test/fixtures/additional-libraries-regexp/expected-remove-es5.js
@@ -1,0 +1,36 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = babelHelpers.interopRequireWildcard(require("react"));
+
+var Greeting =
+/*#__PURE__*/
+function (_Component) {
+  babelHelpers.inherits(Greeting, _Component);
+
+  function Greeting(props, context) {
+    var _this;
+
+    babelHelpers.classCallCheck(this, Greeting);
+    _this = babelHelpers.possibleConstructorReturn(this, babelHelpers.getPrototypeOf(Greeting).call(this, props, context));
+    var appName = context.store.getState().appName;
+    _this.state = {
+      appName: appName
+    };
+    return _this;
+  }
+
+  babelHelpers.createClass(Greeting, [{
+    key: "render",
+    value: function render() {
+      return _react.default.createElement("h1", null, "Welcome ", this.props.name, " and ", this.props.friends.join(', '), " to ", this.state.appName);
+    }
+  }]);
+  return Greeting;
+}(_react.Component);
+
+exports.default = Greeting;

--- a/test/fixtures/additional-libraries-regexp/expected-remove-es6.js
+++ b/test/fixtures/additional-libraries-regexp/expected-remove-es6.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+export default class Greeting extends Component {
+  constructor(props, context) {
+    super(props, context);
+    const appName = context.store.getState().appName;
+    this.state = {
+      appName: appName
+    };
+  }
+
+  render() {
+    return <h1>Welcome {this.props.name} and {this.props.friends.join(', ')} to {this.state.appName}</h1>;
+  }
+
+}

--- a/test/fixtures/additional-libraries-regexp/options.js
+++ b/test/fixtures/additional-libraries-regexp/options.js
@@ -1,0 +1,4 @@
+module.exports = {
+  additionalLibraries: [/\/custom-prop-types$/],
+  removeImport: true
+}


### PR DESCRIPTION
This PR brings new feature (from README.md)

---

#### Regular expressions

 If you are using Babel 7 or newer and your config is stored in [`babel.config.js`](https://babeljs.io/docs/en/configuration#babelconfigjs), you can also use a regular expression to describe modules, which should be removed.

 This would be particularly useful when using custom prop types validators, implemented as part of your own source code. For example

 ```js
 import CustomPropTypes from '../../prop-types/my-own-validator'
 import OtherCustomPropTypes from '../../prop-types/my-other-validator'
 ```

 would be removed with the following setting

 ```js
 additionalLibraries: [/\/prop-types\/.*$/]
 ```

 If you use an index file

 ```js
 import CustomPropTypes from '../../prop-types'
 ```

 you could set it up as

 ```js
 additionalLibraries: [/\/prop-types$/]
 ```