### PR TITLE
safer type checking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,8 @@ export default function(api) {
 
                 return (
                   currentNode.get('callee').node.name === globalOptions.createReactClassName ||
-                  currentNode.get('callee').node.property.name === 'createClass'
+                  (currentNode.get('callee').node.property &&
+                    currentNode.get('callee').node.property.name === 'createClass')
                 )
               })
 

--- a/test/fixtures/react-create-class-custom-name-no-property-name/actual.js
+++ b/test/fixtures/react-create-class-custom-name-no-property-name/actual.js
@@ -1,0 +1,9 @@
+var { createClass } = require('./notReact')
+var PropTypes = require('prop-types')
+
+var Class1 = createClass({
+  displayName: 'Class1',
+  propTypes: {
+    foo: PropTypes.string,
+  },
+})

--- a/test/fixtures/react-create-class-custom-name-no-property-name/expected-remove-es6.js
+++ b/test/fixtures/react-create-class-custom-name-no-property-name/expected-remove-es6.js
@@ -2,11 +2,6 @@ var {
   createClass
 } = require('./notReact');
 
-var PropTypes = require('prop-types');
-
 var Class1 = createClass({
-  displayName: 'Class1',
-  propTypes: {
-    foo: PropTypes.string
-  }
+  displayName: 'Class1'
 });

--- a/test/fixtures/react-create-class-custom-name-no-property-name/expected-remove-es6.js
+++ b/test/fixtures/react-create-class-custom-name-no-property-name/expected-remove-es6.js
@@ -1,0 +1,12 @@
+var {
+  createClass
+} = require('./notReact');
+
+var PropTypes = require('prop-types');
+
+var Class1 = createClass({
+  displayName: 'Class1',
+  propTypes: {
+    foo: PropTypes.string
+  }
+});

--- a/test/fixtures/react-create-class-custom-name-no-property-name/notReact.js
+++ b/test/fixtures/react-create-class-custom-name-no-property-name/notReact.js
@@ -1,0 +1,5 @@
+var createClass = a => a;
+
+module.exports {
+  createClass
+}

--- a/test/fixtures/react-create-class-custom-name-no-property-name/options.json
+++ b/test/fixtures/react-create-class-custom-name-no-property-name/options.json
@@ -1,0 +1,3 @@
+{
+  "createReactClassName": "createSomethingReallySpecial"
+}

--- a/test/fixtures/react-create-class-custom-name-no-property-name/options.json
+++ b/test/fixtures/react-create-class-custom-name-no-property-name/options.json
@@ -1,3 +1,3 @@
 {
-  "createReactClassName": "createSomethingReallySpecial"
+  "createReactClassName": "createClass"
 }


### PR DESCRIPTION
Check for the existence of `node.property` before comparing `node.property.name`

Fixes #178 