### PR TITLE
Fix removing declarator type for unsafe-wrap mode. Fixes #175

### DIFF
--- a/src/remove.js
+++ b/src/remove.js
@@ -105,23 +105,15 @@ export default function remove(path, globalOptions, options) {
         break
 
       case 'declarator':
-        if (mode === 'unsafe-wrap') {
-          path.replaceWith(
-            unsafeWrapTemplate({
-              NODE: path.node,
-            })
+        path.replaceWith(
+          wrapTemplate(
+            {
+              LEFT: path.node.id,
+              RIGHT: path.node.init,
+            },
+            { as: 'variableDeclarator' }
           )
-        } else {
-          path.replaceWith(
-            wrapTemplate(
-              {
-                LEFT: path.node.id,
-                RIGHT: path.node.init,
-              },
-              { as: 'variableDeclarator' }
-            )
-          )
-        }
+        )
         path.node[visitedKey] = true
         break
 

--- a/test/fixtures.test.js
+++ b/test/fixtures.test.js
@@ -13,7 +13,7 @@ import babelPluginProposalObjectRestSpread from '@babel/plugin-proposal-object-r
 import babelPluginTransformReactRemovePropTypes from '../src/index'
 import { trim } from './utils'
 
-const modes = ['options', 'remove-es5', 'wrap-es5', 'remove-es6', 'wrap-es6']
+const modes = ['options', 'remove-es5', 'wrap-es5', 'remove-es6', 'wrap-es6', 'unsafe-wrap-es6']
 
 describe('fixtures', () => {
   const fixturesDir = path.join(__dirname, 'fixtures')
@@ -117,6 +117,25 @@ describe('fixtures', () => {
                     {
                       ...options,
                       mode: 'wrap',
+                    },
+                  ],
+                ],
+              }
+              break
+
+            case 'unsafe-wrap-es6':
+              babelConfig = {
+                babelrc: false,
+                plugins: [
+                  babelPluginExternalHelpers,
+                  babelPluginSyntaxJsx,
+                  babelPluginTransformClassProperties,
+                  babelPluginProposalObjectRestSpread,
+                  [
+                    babelPluginTransformReactRemovePropTypes,
+                    {
+                      ...options,
+                      mode: 'unsafe-wrap',
                     },
                   ],
                 ],

--- a/test/fixtures/bugfix-175/actual.js
+++ b/test/fixtures/bugfix-175/actual.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const sharedPropType = PropTypes.number;
+
+export default class Foo extends React.Component {
+  static propTypes = {
+    bar: sharedPropType,
+  }
+}

--- a/test/fixtures/bugfix-175/expected-unsafe-wrap-es6.js
+++ b/test/fixtures/bugfix-175/expected-unsafe-wrap-es6.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+const sharedPropType = process.env.NODE_ENV !== "production" ? PropTypes.number : {};
+export default class Foo extends React.Component {}
+process.env.NODE_ENV !== "production" ? Foo.propTypes = {
+  bar: sharedPropType
+} : void 0;


### PR DESCRIPTION
This is a fix for https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/issues/175. @lencioni and I figured out that when removing newly unused identifiers in `unsafe-wrap` mode, we should just use the wrapTemplate instead of the unwrapTemplate.

For example, `const sharedPropType = PropTypes.number;` would be transformed into:

unwrapTemplate:
```
if (process.env.NODE_ENV !== "production") {
  const sharedPropType = PropTypes.number; // NOTE the scope issue here! 
}
```

wrapTemplate:
```
const sharedPropType = process.env.NODE_ENV !== "production" ? PropTypes.number : {};
```

Closes #175