### PR TITLE
Add handling for removing propTypes for React.Memo component with implicitly returned

### DIFF
--- a/src/isStatelessComponent.js
+++ b/src/isStatelessComponent.js
@@ -74,6 +74,15 @@ function isReturningJSXElement(path, iteration = 0) {
         }
       }
     },
+    ArrowFunctionExpression(path2) {
+      if (visited) {
+        return
+      }
+
+      if (isJSXElementOrReactCreateElement(path2)) {
+        visited = true
+      }
+    },
   })
 
   return visited

--- a/test/fixtures/stateless-functional-components/actual.js
+++ b/test/fixtures/stateless-functional-components/actual.js
@@ -123,3 +123,11 @@ function Foo12(props) {
 Foo12.propTypes = {
   foo: PropTypes.string,
 };
+
+const Foo13 = React.memo(() => (
+  true && <div />
+));
+
+Foo13.propTypes = {
+  foo: PropTypes.string
+};

--- a/test/fixtures/stateless-functional-components/expected-remove-es5.js
+++ b/test/fixtures/stateless-functional-components/expected-remove-es5.js
@@ -77,3 +77,7 @@ var Foo11 = function Foo11() {
 function Foo12(props) {
   return React.cloneElement(props.children);
 }
+
+var Foo13 = React.memo(function () {
+  return true && React.createElement("div", null);
+});

--- a/test/fixtures/stateless-functional-components/expected-remove-es6.js
+++ b/test/fixtures/stateless-functional-components/expected-remove-es6.js
@@ -71,3 +71,5 @@ const Foo11 = () => true && <div />;
 function Foo12(props) {
   return React.cloneElement(props.children);
 }
+
+const Foo13 = React.memo(() => true && <div />);

--- a/test/fixtures/stateless-functional-components/expected-wrap-es5.js
+++ b/test/fixtures/stateless-functional-components/expected-wrap-es5.js
@@ -125,3 +125,9 @@ function Foo12(props) {
 Foo12.propTypes = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
 } : {};
+var Foo13 = React.memo(function () {
+  return true && React.createElement("div", null);
+});
+Foo13.propTypes = process.env.NODE_ENV !== "production" ? {
+  foo: PropTypes.string
+} : {};

--- a/test/fixtures/stateless-functional-components/expected-wrap-es6.js
+++ b/test/fixtures/stateless-functional-components/expected-wrap-es6.js
@@ -119,3 +119,7 @@ function Foo12(props) {
 Foo12.propTypes = process.env.NODE_ENV !== "production" ? {
   foo: PropTypes.string
 } : {};
+const Foo13 = React.memo(() => true && <div />);
+Foo13.propTypes = process.env.NODE_ENV !== "production" ? {
+  foo: PropTypes.string
+} : {};


### PR DESCRIPTION
Closes https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/issues/196#issuecomment-857658735